### PR TITLE
Support graph options

### DIFF
--- a/.github/workflows/ci_frontend.yml
+++ b/.github/workflows/ci_frontend.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v2
     - name: Set up frontend
       uses: actions/setup-node@v4
       with:
@@ -26,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v2
     - name: Set up frontend
       uses: actions/setup-node@v4
       with:

--- a/exe/diver_down_web
+++ b/exe/diver_down_web
@@ -12,9 +12,9 @@ begin
   # Rack 2.0
   require 'rack'
   require 'rack/server'
-  Rack::Server.new(app:).start
+  Rack::Server.new(app:, server: :webrick).start
 rescue LoadError
   # Rack 3.0
   require 'rackup'
-  Rackup::Server.new(app:).start
+  Rackup::Server.new(app:, server: :webrick).start
 end

--- a/frontend/pages/Home/Show.tsx
+++ b/frontend/pages/Home/Show.tsx
@@ -5,15 +5,19 @@ import { Loading } from '@/components/Loading'
 import { Aside, Section, Sidebar, Stack } from '@/components/ui'
 import { color } from '@/constants/theme'
 import { useBitIdHash } from '@/hooks/useBitIdHash'
+import { useLocalStorage } from '@/hooks/useLocalStorage'
 import { useCombinedDefinition } from '@/repositories/combinedDefinitionRepository'
 
-import { DefinitionGraph } from './components/DefinitionGraph'
+import { DefinitionGraph, GraphOptions } from './components/DefinitionGraph'
 import { DefinitionList } from './components/DefinitionList'
 import { DefinitionSources } from './components/DefinitionSources'
 
 export const Show: React.FC = () => {
   const [selectedDefinitionIds, setSelectedDefinitionIds] = useBitIdHash()
-  const { data: combinedDefinition, isLoading } = useCombinedDefinition(selectedDefinitionIds)
+  const [graphOptions, setGraphOptions] = useLocalStorage<GraphOptions>('HomeShow-GraphOptions', { compound: false })
+  const { data: combinedDefinition, isLoading } = useCombinedDefinition(selectedDefinitionIds, graphOptions.compound)
+
+  console.log({ graphOptions })
 
   return (
     <Wrapper>
@@ -32,7 +36,7 @@ export const Show: React.FC = () => {
             </CenterStack>
           ) : (
             <StyledStack>
-              <DefinitionGraph combinedDefinition={combinedDefinition} />
+              <DefinitionGraph combinedDefinition={combinedDefinition} graphOptions={graphOptions} setGraphOptions={setGraphOptions} />
               <StyledDefinitionSources combinedDefinition={combinedDefinition} />
             </StyledStack>
           )}

--- a/frontend/pages/Home/Show.tsx
+++ b/frontend/pages/Home/Show.tsx
@@ -14,10 +14,8 @@ import { DefinitionSources } from './components/DefinitionSources'
 
 export const Show: React.FC = () => {
   const [selectedDefinitionIds, setSelectedDefinitionIds] = useBitIdHash()
-  const [graphOptions, setGraphOptions] = useLocalStorage<GraphOptions>('HomeShow-GraphOptions', { compound: false })
-  const { data: combinedDefinition, isLoading } = useCombinedDefinition(selectedDefinitionIds, graphOptions.compound)
-
-  console.log({ graphOptions })
+  const [graphOptions, setGraphOptions] = useLocalStorage<GraphOptions>('HomeShow-GraphOptions', { compound: false, concentrate: false })
+  const { data: combinedDefinition, isLoading } = useCombinedDefinition(selectedDefinitionIds, graphOptions.compound, graphOptions.concentrate)
 
   return (
     <Wrapper>

--- a/frontend/pages/Home/Show.tsx
+++ b/frontend/pages/Home/Show.tsx
@@ -14,8 +14,15 @@ import { DefinitionSources } from './components/DefinitionSources'
 
 export const Show: React.FC = () => {
   const [selectedDefinitionIds, setSelectedDefinitionIds] = useBitIdHash()
-  const [graphOptions, setGraphOptions] = useLocalStorage<GraphOptions>('HomeShow-GraphOptions', { compound: false, concentrate: false })
-  const { data: combinedDefinition, isLoading } = useCombinedDefinition(selectedDefinitionIds, graphOptions.compound, graphOptions.concentrate)
+  const [graphOptions, setGraphOptions] = useLocalStorage<GraphOptions>('HomeShow-GraphOptions', {
+    compound: false,
+    concentrate: false,
+  })
+  const { data: combinedDefinition, isLoading } = useCombinedDefinition(
+    selectedDefinitionIds,
+    graphOptions.compound,
+    graphOptions.concentrate,
+  )
 
   return (
     <Wrapper>
@@ -34,7 +41,11 @@ export const Show: React.FC = () => {
             </CenterStack>
           ) : (
             <StyledStack>
-              <DefinitionGraph combinedDefinition={combinedDefinition} graphOptions={graphOptions} setGraphOptions={setGraphOptions} />
+              <DefinitionGraph
+                combinedDefinition={combinedDefinition}
+                graphOptions={graphOptions}
+                setGraphOptions={setGraphOptions}
+              />
               <StyledDefinitionSources combinedDefinition={combinedDefinition} />
             </StyledStack>
           )}

--- a/frontend/pages/Home/components/DefinitionGraph/ConfigureGraphOptionsDialog.tsx
+++ b/frontend/pages/Home/components/DefinitionGraph/ConfigureGraphOptionsDialog.tsx
@@ -1,0 +1,77 @@
+import React, { useCallback, useState } from 'react'
+import styled from 'styled-components'
+
+import { ActionDialog, CheckBox, FormControl, Section, Stack } from '@/components/ui'
+import { spacing } from '@/constants/theme'
+
+export type GraphOptions = {
+  compound: boolean
+}
+
+type Props = {
+  isOpen: boolean
+  onClickClose: () => void
+  graphOptions: GraphOptions
+  setGraphOptions: React.Dispatch<React.SetStateAction<GraphOptions>>
+}
+
+export const ConfigureViewOptionsDialog: React.FC<Props> = ({
+  isOpen,
+  onClickClose,
+  graphOptions,
+  setGraphOptions,
+}) => {
+  const [temporaryViewOptions, setTemporaryViewOptions] =
+    useState<GraphOptions>(graphOptions)
+
+  const handleDialogClose = () => {
+    onClickClose()
+
+    // reset
+    setTemporaryViewOptions(graphOptions)
+  }
+
+  const handleSubmit = () => {
+    setGraphOptions(temporaryViewOptions)
+    onClickClose()
+  }
+
+  const onChangeCompound = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setTemporaryViewOptions((prev) => ({ ...prev, compound: event.target.checked }))
+    },
+    [setTemporaryViewOptions],
+  )
+
+  return (
+    <ActionDialog
+      title="Configure Graph Options"
+      decorators={{ closeButtonLabel: () => 'Close' }}
+      actionText="Save"
+      actionTheme="primary"
+      isOpen={isOpen}
+      onClickAction={handleSubmit}
+      onClickClose={handleDialogClose}
+      onClickOverlay={handleDialogClose}
+      width={'500px'}
+    >
+      <WrapperSection>
+        <Stack gap={1.5}>
+          <Stack gap={1.5}>
+            <p>Configure settings related to the display of definitions.</p>
+
+            <Stack gap={1.5}>
+              <FormControl title="Clip the boundary" helpMessage="Clip the boundary of the module.">
+                <CheckBox name="compound" onChange={onChangeCompound} checked={temporaryViewOptions.compound} />
+              </FormControl>
+            </Stack>
+          </Stack>
+        </Stack>
+      </WrapperSection>
+    </ActionDialog>
+  )
+}
+
+const WrapperSection = styled(Section)`
+  padding: ${spacing.XS};
+`

--- a/frontend/pages/Home/components/DefinitionGraph/ConfigureGraphOptionsDialog.tsx
+++ b/frontend/pages/Home/components/DefinitionGraph/ConfigureGraphOptionsDialog.tsx
@@ -6,6 +6,7 @@ import { spacing } from '@/constants/theme'
 
 export type GraphOptions = {
   compound: boolean
+  concentrate: boolean
 }
 
 type Props = {
@@ -43,6 +44,13 @@ export const ConfigureViewOptionsDialog: React.FC<Props> = ({
     [setTemporaryViewOptions],
   )
 
+  const onChangeConcentrate = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setTemporaryViewOptions((prev) => ({ ...prev, concentrate: event.target.checked }))
+    },
+    [setTemporaryViewOptions],
+  )
+
   return (
     <ActionDialog
       title="Configure Graph Options"
@@ -58,11 +66,15 @@ export const ConfigureViewOptionsDialog: React.FC<Props> = ({
       <WrapperSection>
         <Stack gap={1.5}>
           <Stack gap={1.5}>
-            <p>Configure settings related to the display of definitions.</p>
+            <p>Configure graph settings.</p>
 
             <Stack gap={1.5}>
               <FormControl title="Clip the boundary" helpMessage="Clip the boundary of the module.">
                 <CheckBox name="compound" onChange={onChangeCompound} checked={temporaryViewOptions.compound} />
+              </FormControl>
+
+              <FormControl title="Use edge concentrators" helpMessage="This merges multiedges into a single edge and causes partially parallel edges to share part of their paths.">
+                <CheckBox name="compound" onChange={onChangeConcentrate} checked={temporaryViewOptions.concentrate} />
               </FormControl>
             </Stack>
           </Stack>

--- a/frontend/pages/Home/components/DefinitionGraph/ConfigureGraphOptionsDialog.tsx
+++ b/frontend/pages/Home/components/DefinitionGraph/ConfigureGraphOptionsDialog.tsx
@@ -16,14 +16,8 @@ type Props = {
   setGraphOptions: React.Dispatch<React.SetStateAction<GraphOptions>>
 }
 
-export const ConfigureViewOptionsDialog: React.FC<Props> = ({
-  isOpen,
-  onClickClose,
-  graphOptions,
-  setGraphOptions,
-}) => {
-  const [temporaryViewOptions, setTemporaryViewOptions] =
-    useState<GraphOptions>(graphOptions)
+export const ConfigureViewOptionsDialog: React.FC<Props> = ({ isOpen, onClickClose, graphOptions, setGraphOptions }) => {
+  const [temporaryViewOptions, setTemporaryViewOptions] = useState<GraphOptions>(graphOptions)
 
   const handleDialogClose = () => {
     onClickClose()
@@ -73,7 +67,10 @@ export const ConfigureViewOptionsDialog: React.FC<Props> = ({
                 <CheckBox name="compound" onChange={onChangeCompound} checked={temporaryViewOptions.compound} />
               </FormControl>
 
-              <FormControl title="Use edge concentrators" helpMessage="This merges multiedges into a single edge and causes partially parallel edges to share part of their paths.">
+              <FormControl
+                title="Use edge concentrators"
+                helpMessage="This merges multiedges into a single edge and causes partially parallel edges to share part of their paths."
+              >
                 <CheckBox name="compound" onChange={onChangeConcentrate} checked={temporaryViewOptions.concentrate} />
               </FormControl>
             </Stack>

--- a/frontend/pages/Home/components/DefinitionGraph/DefinitionGraph.tsx
+++ b/frontend/pages/Home/components/DefinitionGraph/DefinitionGraph.tsx
@@ -1,18 +1,24 @@
-import { FC, useEffect, useState } from 'react'
+import { FC, useCallback, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
-import { Heading, LineClamp, Section, Text } from '@/components/ui'
+import { Button, FaGearIcon, Heading, LineClamp, Section, Text } from '@/components/ui'
 import { color } from '@/constants/theme'
 import { CombinedDefinition } from '@/models/combinedDefinition'
 import { renderDot } from '@/utils/renderDot'
 
+import { ConfigureViewOptionsDialog, GraphOptions } from './ConfigureGraphOptionsDialog'
 import { ScrollableSvg } from './ScrollableSvg'
 
 type Props = {
   combinedDefinition: CombinedDefinition
+  graphOptions: GraphOptions
+  setGraphOptions: React.Dispatch<React.SetStateAction<GraphOptions>>
 }
 
-export const DefinitionGraph: FC<Props> = ({ combinedDefinition }) => {
+type DialogType = 'configureViewOptionsDiaglog'
+
+export const DefinitionGraph: FC<Props> = ({ combinedDefinition, graphOptions, setGraphOptions }) => {
+  const [visibleDialog, setVisibleDialog] = useState<DialogType | null>(null)
   const [svg, setSvg] = useState<string>('')
 
   useEffect(() => {
@@ -28,8 +34,18 @@ export const DefinitionGraph: FC<Props> = ({ combinedDefinition }) => {
     loadSvg()
   }, [combinedDefinition.dot, setSvg])
 
+  const onClickCloseDialog = useCallback(() => {
+    setVisibleDialog(null)
+  }, [setVisibleDialog])
+
   return (
     <WrapperSection>
+      <ConfigureViewOptionsDialog
+        isOpen={visibleDialog === 'configureViewOptionsDiaglog'}
+        onClickClose={onClickCloseDialog}
+        graphOptions={graphOptions}
+        setGraphOptions={setGraphOptions}
+      />
       <FixedHeightHeading type="sectionTitle">
         <LineClamp>
           {combinedDefinition.titles.map((title, index) => (
@@ -38,6 +54,14 @@ export const DefinitionGraph: FC<Props> = ({ combinedDefinition }) => {
             </BlockText>
           ))}
         </LineClamp>
+        <Button
+          size="s"
+          square
+          onClick={() => setVisibleDialog('configureViewOptionsDiaglog')}
+          prefix={<FaGearIcon alt="Open Options" />}
+        >
+          Open View Options
+        </Button>
       </FixedHeightHeading>
       <FlexHeightSvgWrapper>
         <ScrollableSvg svg={svg} />

--- a/frontend/pages/Home/components/DefinitionGraph/index.ts
+++ b/frontend/pages/Home/components/DefinitionGraph/index.ts
@@ -1,1 +1,2 @@
 export { DefinitionGraph } from './DefinitionGraph'
+export type { GraphOptions } from "./ConfigureGraphOptionsDialog"

--- a/frontend/pages/Home/components/DefinitionGraph/index.ts
+++ b/frontend/pages/Home/components/DefinitionGraph/index.ts
@@ -1,2 +1,2 @@
 export { DefinitionGraph } from './DefinitionGraph'
-export type { GraphOptions } from "./ConfigureGraphOptionsDialog"
+export type { GraphOptions } from './ConfigureGraphOptionsDialog'

--- a/frontend/repositories/combinedDefinitionRepository.ts
+++ b/frontend/repositories/combinedDefinitionRepository.ts
@@ -35,8 +35,14 @@ const fetchDefinitionShow = async (requestPath: string): Promise<CombinedDefinit
   }
 }
 
-export const useCombinedDefinition = (ids: number[], compound: boolean) => {
-  const requestPath = `${path.api.definitions.show(ids)}?${stringify({ compound: compound ? '1' : null })}`
+const toBooleanFlag = (value: boolean) => (value ? '1' : null)
+
+export const useCombinedDefinition = (ids: number[], compound: boolean, concentrate: boolean) => {
+  const params = {
+    compound: toBooleanFlag(compound),
+    concentrate: toBooleanFlag(concentrate),
+  }
+  const requestPath = `${path.api.definitions.show(ids)}?${stringify(params)}`
   const shouldFetch = ids.length > 0
   const { data, isLoading } = useSWR(shouldFetch ? requestPath : null, fetchDefinitionShow)
 

--- a/frontend/repositories/combinedDefinitionRepository.ts
+++ b/frontend/repositories/combinedDefinitionRepository.ts
@@ -3,6 +3,7 @@ import useSWR from 'swr'
 import { path } from '@/constants/path'
 import { CombinedDefinition } from '@/models/combinedDefinition'
 import { bitIdToIds } from '@/utils/bitId'
+import { stringify } from '@/utils/queryString'
 
 import { get } from './httpRequest'
 
@@ -34,8 +35,8 @@ const fetchDefinitionShow = async (requestPath: string): Promise<CombinedDefinit
   }
 }
 
-export const useCombinedDefinition = (ids: number[]) => {
-  const requestPath = path.api.definitions.show(ids)
+export const useCombinedDefinition = (ids: number[], compound: boolean) => {
+  const requestPath = `${path.api.definitions.show(ids)}?${stringify({ compound: compound ? '1' : null })}`
   const shouldFetch = ids.length > 0
   const { data, isLoading } = useSWR(shouldFetch ? requestPath : null, fetchDefinitionShow)
 

--- a/lib/diver_down/web.rb
+++ b/lib/diver_down/web.rb
@@ -51,7 +51,8 @@ module DiverDown
         action.module(module_name)
       in ['GET', %r{\A/api/definitions/(?<bit_id>\d+)\.json\z}]
         bit_id = Regexp.last_match[:bit_id].to_i
-        action.combine_definitions(bit_id)
+        compound = request.params['compound'] == '1'
+        action.combine_definitions(bit_id, compound)
       in ['GET', %r{\A/api/sources/(?<source>.+)\.json\z}]
         source = Regexp.last_match[:source]
         action.source(source)

--- a/lib/diver_down/web.rb
+++ b/lib/diver_down/web.rb
@@ -52,7 +52,8 @@ module DiverDown
       in ['GET', %r{\A/api/definitions/(?<bit_id>\d+)\.json\z}]
         bit_id = Regexp.last_match[:bit_id].to_i
         compound = request.params['compound'] == '1'
-        action.combine_definitions(bit_id, compound)
+        concentrate = request.params['concentrate'] == '1'
+        action.combine_definitions(bit_id, compound, concentrate)
       in ['GET', %r{\A/api/sources/(?<source>.+)\.json\z}]
         source = Regexp.last_match[:source]
         action.source(source)

--- a/lib/diver_down/web/action.rb
+++ b/lib/diver_down/web/action.rb
@@ -144,7 +144,8 @@ module DiverDown
       # GET /api/definitions/:bit_id.json
       #
       # @param bit_id [Integer]
-      def combine_definitions(bit_id)
+      # @param compound [Boolean]
+      def combine_definitions(bit_id, compound)
         ids = DiverDown::Web::BitId.bit_id_to_ids(bit_id)
 
         valid_ids = ids.select do
@@ -167,7 +168,7 @@ module DiverDown
           json(
             titles:,
             bit_id: DiverDown::Web::BitId.ids_to_bit_id(valid_ids).to_s,
-            dot: DiverDown::Web::DefinitionToDot.new(definition).to_s,
+            dot: DiverDown::Web::DefinitionToDot.new(definition, compound:).to_s,
             sources: definition.sources.map do
               {
                 source_name: _1.source_name,

--- a/lib/diver_down/web/action.rb
+++ b/lib/diver_down/web/action.rb
@@ -145,7 +145,8 @@ module DiverDown
       #
       # @param bit_id [Integer]
       # @param compound [Boolean]
-      def combine_definitions(bit_id, compound)
+      # @param concentrate [Boolean]
+      def combine_definitions(bit_id, compound, concentrate)
         ids = DiverDown::Web::BitId.bit_id_to_ids(bit_id)
 
         valid_ids = ids.select do
@@ -168,7 +169,7 @@ module DiverDown
           json(
             titles:,
             bit_id: DiverDown::Web::BitId.ids_to_bit_id(valid_ids).to_s,
-            dot: DiverDown::Web::DefinitionToDot.new(definition, compound:).to_s,
+            dot: DiverDown::Web::DefinitionToDot.new(definition, compound:, concentrate:).to_s,
             sources: definition.sources.map do
               {
                 source_name: _1.source_name,

--- a/lib/diver_down/web/definition_to_dot.rb
+++ b/lib/diver_down/web/definition_to_dot.rb
@@ -82,11 +82,13 @@ module DiverDown
 
       # @param definition [DiverDown::Definition]
       # @param compound [Boolean]
-      def initialize(definition, compound: false)
+      # @param concentrate [Boolean] https://graphviz.org/docs/attrs/concentrate/
+      def initialize(definition, compound: false, concentrate: false)
         @definition = definition
         @io = DiverDown::IndentedStringIo.new
         @indent = 0
         @compound = compound
+        @concentrate = concentrate
       end
 
       # @return [String]
@@ -98,6 +100,7 @@ module DiverDown
         io.puts %(strict digraph "#{definition.title}" {)
         io.indented do
           io.puts('compound=true') if @compound
+          io.puts('concentrate=true') if @concentrate
           sources.each do
             insert_source(_1)
           end

--- a/lib/diver_down/web/definition_to_dot.rb
+++ b/lib/diver_down/web/definition_to_dot.rb
@@ -79,26 +79,16 @@ module DiverDown
       end
 
       # @param definition [DiverDown::Definition]
-      def initialize(definition)
+      # @param compound [Boolean]
+      def initialize(definition, compound: false)
         @definition = definition
         @io = DiverDown::IndentedStringIo.new
         @indent = 0
+        @compound = compound
       end
 
       # @return [String]
       def to_s
-        # <<~EOS
-        #   digraph G {
-        #     compound=true;
-        #     subgraph cluster0 {
-        #       b -> d;
-        #     }
-        #     subgraph cluster1 {
-        #       e -> f;
-        #     }
-        #     b -> e [ltail=cluster0,lhead=cluster1];
-        #   }
-        # EOS
         sources = definition.sources
           .sort_by(&:source_name)
           .map { SourceDecorator.new(_1) }
@@ -124,13 +114,11 @@ module DiverDown
           insert_modules(source)
         end
 
-        io.indented do
-          source.dependencies.each do
-            attributes = build_attributes(tooltip: _1.tooltip)
-            io.write %("#{source.source_name}" -> "#{_1.source_name}")
-            io.write %( #{attributes}) if attributes
-            io.write "\n"
-          end
+        source.dependencies.each do
+          attributes = build_attributes(tooltip: _1.tooltip)
+          io.write %("#{source.source_name}" -> "#{_1.source_name}")
+          io.write %( #{attributes}) if attributes
+          io.write "\n"
         end
       end
 
@@ -140,7 +128,7 @@ module DiverDown
 
           # last subgraph
           last_module_writer = proc do
-            io.puts %( subgraph "cluster_#{last_module.module_name}" {), indent: false
+            io.puts %(#{' ' unless modules.empty?}subgraph "cluster_#{last_module.module_name}" {), indent: false
             io.indented do
               source_attributes = build_attributes(label: last_module.module_name, _wrap: false)
               module_attributes = build_attributes(label: source.source_name)
@@ -173,9 +161,9 @@ module DiverDown
 
       # rubocop:disable Lint/UnderscorePrefixedVariableName
       # attrsの参考 https://qiita.com/rubytomato@github/items/51779135bc4b77c8c20d
-      # attrs.merge!(label: 'a-b', headlabel: "head", taillabel: "tail")
       def build_attributes(_wrap: '[]', **attrs)
         attrs_str = attrs.filter_map { %(#{_1}="#{_2}") if _2 }.join(' ')
+        attrs.merge!(label: 'a-b', headlabel: "head", taillabel: "tail")
 
         return if attrs_str.empty?
 

--- a/lib/diver_down/web/definition_to_dot.rb
+++ b/lib/diver_down/web/definition_to_dot.rb
@@ -3,6 +3,8 @@
 module DiverDown
   class Web
     class DefinitionToDot
+      ATTRIBUTE_DELIMITER = ' '
+
       class SourceDecorator < BasicObject
         attr_reader :dependencies
 
@@ -119,10 +121,10 @@ module DiverDown
           attributes = {}
 
           if @compound
-            attributes.merge!(
-              lhead: module_label(*source.modules),
-              ltail: module_label(*definition.source(_1.source_name).modules)
-            )
+            ltail = module_label(*source.modules)
+            lhead = module_label(*definition.source(_1.source_name).modules)
+
+            attributes.merge!(ltail:, lhead:)
           end
 
           io.write(%("#{source.source_name}" -> "#{_1.source_name}"))
@@ -171,7 +173,7 @@ module DiverDown
       # rubocop:disable Lint/UnderscorePrefixedVariableName
       # attrsの参考 https://qiita.com/rubytomato@github/items/51779135bc4b77c8c20d
       def build_attributes(_wrap: '[]', **attrs)
-        attrs_str = attrs.filter_map { %(#{_1}="#{_2}") if _2 }.join(' ')
+        attrs_str = attrs.filter_map { %(#{_1}="#{_2}") if _2 }.join(ATTRIBUTE_DELIMITER)
         attrs.merge!(label: 'a-b', headlabel: 'head', taillabel: 'tail')
 
         return if attrs_str.empty?

--- a/spec/diver_down/web/definition_to_dot_spec.rb
+++ b/spec/diver_down/web/definition_to_dot_spec.rb
@@ -54,6 +54,9 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
                   },
                 ],
               },
+              {
+                source_name: 'b.rb',
+              }
             ]
           )
 
@@ -61,6 +64,7 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
             strict digraph "title" {
               "a.rb" [label="a.rb"]
               "a.rb" -> "b.rb"
+              "b.rb" [label="b.rb"]
             }
           DOT
         end
@@ -79,7 +83,7 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
                     module_name: 'B',
                   },
                 ],
-              },
+              }
             ]
           )
 
@@ -137,8 +141,7 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
               subgraph "cluster_A" {
                 label="A" "a.rb" [label="a.rb"]
               }
-              "a.rb" -> "b.rb" [ltail="cluster_A" lhead="cluster_B"]
-              "a.rb" -> "c.rb" [ltail="cluster_A" lhead="cluster_B"]
+              "a.rb" -> "b.rb" [ltail="cluster_A" lhead="cluster_B" minlen="3"]
               subgraph "cluster_B" {
                 label="B" "b.rb" [label="b.rb"]
               }

--- a/spec/diver_down/web/definition_to_dot_spec.rb
+++ b/spec/diver_down/web/definition_to_dot_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
           expect(described_class.new(definition).to_s).to eq(<<~DOT)
             strict digraph "title" {
               "a.rb" [label="a.rb"]
-                "a.rb" -> "b.rb"
+              "a.rb" -> "b.rb"
             }
           DOT
         end

--- a/spec/diver_down/web/definition_to_dot_spec.rb
+++ b/spec/diver_down/web/definition_to_dot_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
               },
               {
                 source_name: 'b.rb',
-              }
+              },
             ]
           )
 
@@ -83,7 +83,7 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
                     module_name: 'B',
                   },
                 ],
-              }
+              },
             ]
           )
 

--- a/spec/diver_down/web/definition_to_dot_spec.rb
+++ b/spec/diver_down/web/definition_to_dot_spec.rb
@@ -101,6 +101,46 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
             }
           DOT
         end
+
+        it 'returns composed digraph if composed = true' do
+          definition = build_definition(
+            sources: [
+              {
+                source_name: 'a.rb',
+                modules: [
+                  {
+                    module_name: 'A',
+                  },
+                ],
+                dependencies: [
+                  {
+                    source_name: 'b.rb',
+                  },
+                ],
+              }, {
+                source_name: 'b.rb',
+                modules: [
+                  {
+                    module_name: 'B',
+                  },
+                ],
+                dependencies: [],
+              },
+            ]
+          )
+
+          expect(described_class.new(definition, compound: true).to_s).to eq(<<~DOT)
+            strict digraph "title" {
+              subgraph "cluster_A" {
+                label="A" "a.rb" [label="a.rb"]
+              }
+              "a.rb" -> "b.rb" [lhead="cluster_A" ltail="cluster_B"]
+              subgraph "cluster_B" {
+                label="B" "b.rb" [label="b.rb"]
+              }
+            }
+          DOT
+        end
       end
     end
   end

--- a/spec/diver_down/web/definition_to_dot_spec.rb
+++ b/spec/diver_down/web/definition_to_dot_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
           DOT
         end
 
-        it 'returns composed digraph if composed = true' do
+        it 'returns compound digraph if compound = true' do
           definition = build_definition(
             sources: [
               {
@@ -115,10 +115,20 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
                 dependencies: [
                   {
                     source_name: 'b.rb',
+                  }, {
+                    source_name: 'c.rb',
                   },
                 ],
               }, {
                 source_name: 'b.rb',
+                modules: [
+                  {
+                    module_name: 'B',
+                  },
+                ],
+                dependencies: [],
+              }, {
+                source_name: 'c.rb',
                 modules: [
                   {
                     module_name: 'B',
@@ -131,12 +141,17 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
 
           expect(described_class.new(definition, compound: true).to_s).to eq(<<~DOT)
             strict digraph "title" {
+              compound=true
               subgraph "cluster_A" {
                 label="A" "a.rb" [label="a.rb"]
               }
-              "a.rb" -> "b.rb" [lhead="cluster_A" ltail="cluster_B"]
+              "a.rb" -> "b.rb" [ltail="cluster_A" lhead="cluster_B"]
+              "a.rb" -> "c.rb" [ltail="cluster_A" lhead="cluster_B"]
               subgraph "cluster_B" {
                 label="B" "b.rb" [label="b.rb"]
+              }
+              subgraph "cluster_B" {
+                label="B" "c.rb" [label="c.rb"]
               }
             }
           DOT

--- a/spec/diver_down/web/definition_to_dot_spec.rb
+++ b/spec/diver_down/web/definition_to_dot_spec.rb
@@ -5,15 +5,7 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
     describe '#to_s' do
       def build_definition(title: 'title', sources: [])
         definition_sources = sources.map do |source|
-          dependencies = (source[:dependencies] || []).map do |dependency|
-            DiverDown::Definition::Dependency.new(**dependency)
-          end
-
-          modules = (source[:modules] || []).map do |mod|
-            DiverDown::Definition::Modulee.new(**mod)
-          end
-
-          DiverDown::Definition::Source.new(**source, dependencies:, modules:)
+          DiverDown::Definition::Source.from_hash(source)
         end
 
         DiverDown::Definition.new(title:, sources: definition_sources)
@@ -153,6 +145,23 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
               subgraph "cluster_B" {
                 label="B" "c.rb" [label="c.rb"]
               }
+            }
+          DOT
+        end
+
+        it 'returns concentrate digraph if concentrate = true' do
+          definition = build_definition(
+            sources: [
+              {
+                source_name: 'a.rb',
+              },
+            ]
+          )
+
+          expect(described_class.new(definition, concentrate: true).to_s).to eq(<<~DOT)
+            strict digraph "title" {
+              concentrate=true
+              "a.rb" [label="a.rb"]
             }
           DOT
         end

--- a/spec/diver_down/web_spec.rb
+++ b/spec/diver_down/web_spec.rb
@@ -424,6 +424,25 @@ RSpec.describe DiverDown::Web do
       expect(last_response.headers['content-type']).to eq('application/json')
       expect(last_response.body).to include('digraph')
     end
+
+    it 'returns combined definition with compound=true' do
+      definition = DiverDown::Definition.new(
+        title: 'title',
+        sources: [
+          DiverDown::Definition::Source.new(
+            source_name: 'a.rb'
+          ),
+        ]
+      )
+      bit_ids = store.set(definition)
+
+      get "/api/definitions/#{bit_ids.inject(0, &:|)}.json", compound: '1'
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.headers['content-type']).to eq('application/json')
+      expect(last_response.body).to include('digraph')
+      expect(last_response.body).to include('compound')
+    end
   end
 
   describe 'GET /api/sources/:source.json' do


### PR DESCRIPTION
- The server is set up with webrick. To make it a single process and share DefinitionStore.
- Add `concentrate` option to group rows together for easier viewing.
- Add `compound` option to display dependencies between modules in a single row for better visibility.