### PR TITLE
Render multiple methods when compound=true

### DIFF
--- a/frontend/models/combinedDefinition.ts
+++ b/frontend/models/combinedDefinition.ts
@@ -4,23 +4,25 @@ type BaseDotMetadata = {
   id: string
 }
 
-type DotSourceMetadata = {
+export type DotSourceMetadata = {
   type: 'source'
   sourceName: string
   modules: Module[]
 } & BaseDotMetadata
 
-type DotDependencyMetadata = {
+export type DotDependencyMetadata = {
   type: 'dependency'
-  sourceName: string
-  methodIds: Array<{
-    name: string
-    context: 'class' | 'instance'
-    human: string
+  dependencies: Array<{
+    sourceName: string
+    methodIds: Array<{
+      name: string
+      context: 'class' | 'instance'
+      human: string
+    }>
   }>
 } & BaseDotMetadata
 
-type DotModuleMetadata = {
+export type DotModuleMetadata = {
   type: 'module'
   modules: Module[]
 } & BaseDotMetadata

--- a/frontend/pages/Home/components/DefinitionGraph/ScrollableSvg.tsx
+++ b/frontend/pages/Home/components/DefinitionGraph/ScrollableSvg.tsx
@@ -127,11 +127,6 @@ export const ScrollableSvg: FC<Props> = ({ combinedDefinition, setVisibleDialog 
               ) ?? null
             )
           case 'dependency':
-            return (
-              combinedDefinition.dotMetadata.find(
-                (metadata) => metadata.type === 'dependency' && metadata.sourceName === prev.sourceName,
-              ) ?? null
-            )
           case 'module':
             // Can't find previous module
             return prev

--- a/frontend/repositories/combinedDefinitionRepository.ts
+++ b/frontend/repositories/combinedDefinitionRepository.ts
@@ -19,10 +19,12 @@ type DotSourceMetadataResponse = {
 type DotDependencyMetadataResponse = {
   id: string
   type: 'dependency'
-  source_name: string
-  method_ids: Array<{
-    name: string
-    context: 'class' | 'instance'
+  dependencies: Array<{
+    source_name: string
+    method_ids: Array<{
+      name: string
+      context: 'class' | 'instance'
+    }>
   }>
 }
 
@@ -65,11 +67,13 @@ const parseDotMetadata = (metadata: DotMetadataResponse): DotMetadata => {
       return {
         id: metadata.id,
         type: metadata.type,
-        sourceName: metadata.source_name,
-        methodIds: metadata.method_ids.map((methodId) => ({
-          name: methodId.name,
-          context: methodId.context,
-          human: `${methodId.context === 'class' ? '.' : '#'}${methodId.name}`,
+        dependencies: metadata.dependencies.map((dependency) => ({
+          sourceName: dependency.source_name,
+          methodIds: dependency.method_ids.map((methodId) => ({
+            name: methodId.name,
+            context: methodId.context,
+            human: `${methodId.context === 'class' ? '.' : '#'}${methodId.name}`,
+          })),
         })),
       }
     }

--- a/lib/diver_down/web/definition_to_dot.rb
+++ b/lib/diver_down/web/definition_to_dot.rb
@@ -223,12 +223,11 @@ module DiverDown
             module_names = all_module_names
             module_name = module_names[-1]
 
-            io.puts %(#{' ' unless head_module_indexes.empty?}subgraph "#{module_label(module_name)}" {), indent: false
+            io.puts %(subgraph "#{module_label(module_name)}" {)
             io.indented do
-              module_attributes = build_attributes(label: module_name, id: @metadata_store.issue_modules_id(module_names), _wrap: false)
-              source_attributes = build_attributes(label: source.source_name, id: @metadata_store.issue_source_id(source))
-
-              io.puts %(#{module_attributes} "#{source.source_name}" #{source_attributes})
+              io.puts %(id="#{@metadata_store.issue_modules_id(module_names)}")
+              io.puts %(label="#{module_name}")
+              io.puts %("#{source.source_name}" #{build_attributes(label: source.source_name, id: @metadata_store.issue_source_id(source))})
             end
             io.puts '}'
           end
@@ -241,8 +240,8 @@ module DiverDown
 
               io.puts %(subgraph "#{module_label(module_name)}" {)
               io.indented do
-                attributes = build_attributes(label: module_name, id: @metadata_store.issue_modules_id(module_names), _wrap: false)
-                io.write attributes
+                io.puts %(id="#{@metadata_store.issue_modules_id(module_names)}")
+                io.puts %(label="#{module_name}")
                 next_writer.call
               end
               io.puts '}'

--- a/spec/diver_down/web/definition_to_dot_spec.rb
+++ b/spec/diver_down/web/definition_to_dot_spec.rb
@@ -130,8 +130,12 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
           expect(instance.to_s).to eq(<<~DOT)
             strict digraph "title" {
               subgraph "cluster_A" {
-                label="A" id="graph_1" subgraph "cluster_B" {
-                  label="B" id="graph_2" "a.rb" [label="a.rb" id="graph_3"]
+                id="graph_1"
+                label="A"
+                subgraph "cluster_B" {
+                  id="graph_2"
+                  label="B"
+                  "a.rb" [label="a.rb" id="graph_3"]
                 }
               }
             }
@@ -199,14 +203,20 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
             strict digraph "title" {
               compound=true
               subgraph "cluster_A" {
-                label="A" id="graph_1" "a.rb" [label="a.rb" id="graph_2"]
+                id="graph_1"
+                label="A"
+                "a.rb" [label="a.rb" id="graph_2"]
               }
               "a.rb" -> "b.rb" [id="graph_3" ltail="cluster_A" lhead="cluster_B" minlen="3"]
               subgraph "cluster_B" {
-                label="B" id="graph_4" "b.rb" [label="b.rb" id="graph_5"]
+                id="graph_4"
+                label="B"
+                "b.rb" [label="b.rb" id="graph_5"]
               }
               subgraph "cluster_B" {
-                label="B" id="graph_6" "c.rb" [label="c.rb" id="graph_7"]
+                id="graph_6"
+                label="B"
+                "c.rb" [label="c.rb" id="graph_7"]
               }
             }
           DOT
@@ -318,14 +328,20 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
             strict digraph "title" {
               compound=true
               subgraph "cluster_A" {
-                label="A" id="graph_1" "a.rb" [label="a.rb" id="graph_2"]
+                id="graph_1"
+                label="A"
+                "a.rb" [label="a.rb" id="graph_2"]
               }
               "a.rb" -> "b.rb" [id="graph_3" ltail="cluster_A" lhead="cluster_B" minlen="3"]
               subgraph "cluster_B" {
-                label="B" id="graph_4" "b.rb" [label="b.rb" id="graph_5"]
+                id="graph_4"
+                label="B"
+                "b.rb" [label="b.rb" id="graph_5"]
               }
               subgraph "cluster_B" {
-                label="B" id="graph_6" "c.rb" [label="c.rb" id="graph_7"]
+                id="graph_6"
+                label="B"
+                "c.rb" [label="c.rb" id="graph_7"]
               }
             }
           DOT
@@ -403,7 +419,6 @@ RSpec.describe DiverDown::Web::DefinitionToDot do
             ]
           )
         end
-
 
         it 'returns concentrate digraph if concentrate = true' do
           definition = build_definition(


### PR DESCRIPTION
If compound=true, only one dependency edge between modules is shown, but there may be multiple actual dependencies.
In this PR, only one edge is displayed, but the dependency is changed to be kept in multiple metadata.