### PR TITLE
Allow parsing process to be performed without passing a block

### DIFF
--- a/lib/diver_down-web.rb
+++ b/lib/diver_down-web.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+require 'diver_down'
 require 'diver_down/web'

--- a/lib/diver_down.rb
+++ b/lib/diver_down.rb
@@ -7,6 +7,7 @@ module DiverDown
   class Error < StandardError; end
 
   DELIMITER = ','
+  LIB_DIR = __dir__
 
   require 'diver_down/definition'
   require 'diver_down/helper'

--- a/lib/diver_down/trace.rb
+++ b/lib/diver_down/trace.rb
@@ -5,6 +5,7 @@ require 'active_support/inflector'
 module DiverDown
   module Trace
     require 'diver_down/trace/tracer'
+    require 'diver_down/trace/tracer/session'
     require 'diver_down/trace/call_stack'
     require 'diver_down/trace/module_set'
     require 'diver_down/trace/redefine_ruby_methods'

--- a/lib/diver_down/trace/module_set.rb
+++ b/lib/diver_down/trace/module_set.rb
@@ -8,7 +8,7 @@ module DiverDown
       require 'diver_down/trace/module_set/const_source_location_module_set'
 
       # @param [Array<Module, String>, Set<Module, String>, nil] modules
-      # @param [Array<String>] include
+      # @param [Array<String>, Set<String>, nil] include
       def initialize(modules: nil, paths: nil)
         @cache = {}
         @array_module_set = DiverDown::Trace::ModuleSet::ArrayModuleSet.new(modules) unless modules.nil?
@@ -41,6 +41,8 @@ module DiverDown
       private
 
       def _include?(mod)
+        return true if @array_module_set.nil? && @const_source_location_module_set.nil?
+
         @array_module_set&.include?(mod) ||
           @const_source_location_module_set&.include?(mod)
       end

--- a/lib/diver_down/trace/tracer.rb
+++ b/lib/diver_down/trace/tracer.rb
@@ -62,91 +62,34 @@ module DiverDown
       # @param definition_group [String, nil]
       #
       # @return [DiverDown::Definition]
-      def trace(title:, definition_group: nil, &)
-        call_stack = DiverDown::Trace::CallStack.new
-        definition = DiverDown::Definition.new(
-          definition_group:,
-          title:
-        )
+      def trace(title: SecureRandom.uuid, definition_group: nil, &)
+        session = new_session(title:, definition_group:)
+        session.start
 
-        ignored_stack_size = nil
+        yield
 
-        tracer = TracePoint.new(*self.class.trace_events) do |tp|
-          case tp.event
-          when :call, :c_call
-            # puts "#{tp.method_id} #{tp.path}:#{tp.lineno}"
-            mod = DiverDown::Helper.resolve_module(tp.self)
-            source_name = DiverDown::Helper.normalize_module_name(mod) if !mod.nil? && @module_set.include?(mod)
-            already_ignored = !ignored_stack_size.nil? # If the current method_id is ignored
-            current_ignored = !@ignored_method_ids.nil? && @ignored_method_ids.ignored?(mod, DiverDown::Helper.module?(tp.self), tp.method_id)
-            pushed = false
-
-            if !source_name.nil? && !(already_ignored || current_ignored)
-              source = definition.find_or_build_source(source_name)
-
-              # If the call stack contains a call to a module to be traced
-              # `@ignored_call_stack` is not nil means the call stack contains a call to a module to be ignored
-              unless call_stack.empty?
-                # Add dependency to called source
-                called_stack_context = call_stack.stack[-1]
-                called_source = called_stack_context.source
-                dependency = called_source.find_or_build_dependency(source_name)
-
-                # `dependency.nil?` means source_name equals to called_source.source.
-                # self-references are not tracked because it is not "dependency".
-                if dependency
-                  context = DiverDown::Helper.module?(tp.self) ? 'class' : 'instance'
-                  method_id = dependency.find_or_build_method_id(name: tp.method_id, context:)
-                  method_id_path = "#{called_stack_context.caller_location.path}:#{called_stack_context.caller_location.lineno}"
-                  method_id_path = @filter_method_id_path.call(method_id_path) if @filter_method_id_path
-                  method_id.add_path(method_id_path)
-                end
-              end
-
-              # `caller_location` is nil if it is filtered by target_files
-              caller_location = find_neast_caller_location
-
-              if caller_location
-                pushed = true
-
-                call_stack.push(
-                  StackContext.new(
-                    source:,
-                    method_id: tp.method_id,
-                    caller_location:
-                  )
-                )
-              end
-            end
-
-            call_stack.push unless pushed
-
-            # If a value is already stored, it means that call stack already determined to be ignored at the shallower call stack size.
-            # Since stacks deeper than the shallowest stack size are ignored, priority is given to already stored values.
-            if !already_ignored && current_ignored
-              ignored_stack_size = call_stack.stack_size
-            end
-          when :return, :c_return
-            ignored_stack_size = nil if ignored_stack_size == call_stack.stack_size
-            call_stack.pop
-          end
-        end
-
-        tracer.enable(&)
-
-        definition
+        session.stop
+        session.definition
+      ensure
+        # Ensure to stop the session
+        session&.stop
       end
 
-      private
-
-      def find_neast_caller_location
-        return caller_locations(2, 2)[0] if @target_file_set.nil?
-
-        Thread.each_caller_location do
-          return _1 if @target_file_set.include?(_1.path)
-        end
-
-        nil
+      # @param title [String]
+      # @param definition_group [String, nil]
+      #
+      # @return [TracePoint]
+      def new_session(title: SecureRandom.uuid, definition_group: nil)
+        DiverDown::Trace::Tracer::Session.new(
+          module_set: @module_set,
+          ignored_method_ids: @ignored_method_ids,
+          target_file_set: @target_file_set,
+          filter_method_id_path: @filter_method_id_path,
+          definition: DiverDown::Definition.new(
+            title:,
+            definition_group:
+          )
+        )
       end
     end
   end

--- a/lib/diver_down/trace/tracer.rb
+++ b/lib/diver_down/trace/tracer.rb
@@ -69,7 +69,7 @@ module DiverDown
           title:
         )
 
-        @ignored_stack_size = nil
+        ignored_stack_size = nil
 
         tracer = TracePoint.new(*self.class.trace_events) do |tp|
           case tp.event
@@ -77,7 +77,7 @@ module DiverDown
             # puts "#{tp.method_id} #{tp.path}:#{tp.lineno}"
             mod = DiverDown::Helper.resolve_module(tp.self)
             source_name = DiverDown::Helper.normalize_module_name(mod) if !mod.nil? && @module_set.include?(mod)
-            already_ignored = !@ignored_stack_size.nil? # If the current method_id is ignored
+            already_ignored = !ignored_stack_size.nil? # If the current method_id is ignored
             current_ignored = !@ignored_method_ids.nil? && @ignored_method_ids.ignored?(mod, DiverDown::Helper.module?(tp.self), tp.method_id)
             pushed = false
 
@@ -124,10 +124,10 @@ module DiverDown
             # If a value is already stored, it means that call stack already determined to be ignored at the shallower call stack size.
             # Since stacks deeper than the shallowest stack size are ignored, priority is given to already stored values.
             if !already_ignored && current_ignored
-              @ignored_stack_size = call_stack.stack_size
+              ignored_stack_size = call_stack.stack_size
             end
           when :return, :c_return
-            @ignored_stack_size = nil if @ignored_stack_size == call_stack.stack_size
+            ignored_stack_size = nil if ignored_stack_size == call_stack.stack_size
             call_stack.pop
           end
         end

--- a/lib/diver_down/trace/tracer.rb
+++ b/lib/diver_down/trace/tracer.rb
@@ -24,7 +24,7 @@ module DiverDown
       # @param ignored_method_ids [Array<String>]
       # @param filter_method_id_path [#call, nil] filter method_id.path
       # @param module_set [DiverDown::Trace::ModuleSet, nil] for optimization
-      def initialize(module_set: [], target_files: nil, ignored_method_ids: nil, filter_method_id_path: nil)
+      def initialize(module_set: {}, target_files: nil, ignored_method_ids: nil, filter_method_id_path: nil)
         if target_files && !target_files.all? { Pathname.new(_1).absolute? }
           raise ArgumentError, "target_files must be absolute path(#{target_files})"
         end
@@ -34,7 +34,16 @@ module DiverDown
                       elsif module_set.is_a?(Hash)
                         DiverDown::Trace::ModuleSet.new(**module_set)
                       else
-                        DiverDown::Trace::ModuleSet.new(modules: module_set)
+                        raise ArgumentError, <<~MSG
+                          Given invalid module_set. #{module_set}"
+
+                          Available types are:
+
+                          Hash{
+                            modules: Array<Module, String> | Set<Module, String> | nil
+                            paths: Array<String> | Set<String> | nil
+                          } | DiverDown::Trace::ModuleSet
+                        MSG
                       end
 
         @ignored_method_ids = if ignored_method_ids.is_a?(DiverDown::Trace::IgnoredMethodIds)

--- a/lib/diver_down/trace/tracer/session.rb
+++ b/lib/diver_down/trace/tracer/session.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module DiverDown
+  module Trace
+    class Tracer
+      class Session
+        class NotStarted < StandardError; end
+
+        attr_reader :definition
+
+        # @param [DiverDown::Trace::ModuleSet, nil] module_set
+        # @param [DiverDown::Trace::IgnoredMethodIds, nil] ignored_method_ids
+        # @param [Set<String>, nil] target_file_set
+        # @param [#call, nil] filter_method_id_path
+        def initialize(module_set: DiverDown::Trace::ModuleSet.new, ignored_method_ids: nil, target_file_set: nil, filter_method_id_path: nil, definition: DiverDown::Definition.new)
+          @module_set = module_set
+          @ignored_method_ids = ignored_method_ids
+          @target_file_set = target_file_set
+          @filter_method_id_path = filter_method_id_path
+          @definition = definition
+          @trace_point = build_trace_point
+        end
+
+        # @return [void]
+        def start
+          @trace_point.enable
+        end
+
+        # @return [void]
+        def stop
+          @trace_point.disable
+        end
+
+        private
+
+        def build_trace_point
+          call_stack = DiverDown::Trace::CallStack.new
+          ignored_stack_size = nil
+
+          TracePoint.new(*DiverDown::Trace::Tracer.trace_events) do |tp|
+            # Skip the trace of the library itself
+            next if tp.path&.start_with?(DiverDown::LIB_DIR)
+            next if TracePoint == tp.defined_class
+
+            case tp.event
+            when :call, :c_call
+              # puts "#{tp.method_id} #{tp.path}:#{tp.lineno}"
+              mod = DiverDown::Helper.resolve_module(tp.self)
+              source_name = DiverDown::Helper.normalize_module_name(mod) if !mod.nil? && @module_set.include?(mod)
+              already_ignored = !ignored_stack_size.nil? # If the current method_id is ignored
+              current_ignored = !@ignored_method_ids.nil? && @ignored_method_ids.ignored?(mod, DiverDown::Helper.module?(tp.self), tp.method_id)
+              pushed = false
+
+              if !source_name.nil? && !(already_ignored || current_ignored)
+                source = @definition.find_or_build_source(source_name)
+
+                # If the call stack contains a call to a module to be traced
+                # `@ignored_call_stack` is not nil means the call stack contains a call to a module to be ignored
+                unless call_stack.empty?
+                  # Add dependency to called source
+                  called_stack_context = call_stack.stack[-1]
+                  called_source = called_stack_context.source
+                  dependency = called_source.find_or_build_dependency(source_name)
+
+                  # `dependency.nil?` means source_name equals to called_source.source.
+                  # self-references are not tracked because it is not "dependency".
+                  if dependency
+                    context = DiverDown::Helper.module?(tp.self) ? 'class' : 'instance'
+                    method_id = dependency.find_or_build_method_id(name: tp.method_id, context:)
+                    method_id_path = "#{called_stack_context.caller_location.path}:#{called_stack_context.caller_location.lineno}"
+                    method_id_path = @filter_method_id_path.call(method_id_path) if @filter_method_id_path
+                    method_id.add_path(method_id_path)
+                  end
+                end
+
+                # `caller_location` is nil if it is filtered by target_files
+                caller_location = find_neast_caller_location
+
+                if caller_location
+                  pushed = true
+
+                  call_stack.push(
+                    StackContext.new(
+                      source:,
+                      method_id: tp.method_id,
+                      caller_location:
+                    )
+                  )
+                end
+              end
+
+              call_stack.push unless pushed
+
+              # If a value is already stored, it means that call stack already determined to be ignored at the shallower call stack size.
+              # Since stacks deeper than the shallowest stack size are ignored, priority is given to already stored values.
+              if !already_ignored && current_ignored
+                ignored_stack_size = call_stack.stack_size
+              end
+            when :return, :c_return
+              ignored_stack_size = nil if ignored_stack_size == call_stack.stack_size
+              call_stack.pop
+            end
+          rescue StandardError
+            tp.disable
+            raise
+          end
+        end
+
+        def find_neast_caller_location
+          return caller_locations(2, 2)[0] if @target_file_set.nil?
+
+          Thread.each_caller_location do
+            return _1 if @target_file_set.include?(_1.path)
+          end
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/spec/diver_down/trace/module_set_spec.rb
+++ b/spec/diver_down/trace/module_set_spec.rb
@@ -3,6 +3,18 @@
 RSpec.describe DiverDown::Trace::ModuleSet do
   describe 'InstanceMethods' do
     describe '#include?' do
+      context 'without options' do
+        it 'always returns true' do
+          stub_const('A', Module.new)
+          stub_const('B', Module.new)
+
+          set = described_class.new
+
+          expect(set.include?(A)).to be(true)
+          expect(set.include?(B)).to be(true)
+        end
+      end
+
       context 'with modules' do
         it 'checks module or module name' do
           stub_const('A', Module.new)

--- a/spec/diver_down/trace/tracer_spec.rb
+++ b/spec/diver_down/trace/tracer_spec.rb
@@ -11,13 +11,23 @@ RSpec.describe DiverDown::Trace::Tracer do
         }.to raise_error(ArgumentError, /target_files must be absolute path/)
       end
     end
+
+    context 'given invalid module_set' do
+      it 'raises ArgumentError' do
+        expect {
+          described_class.new(
+            module_set: []
+          )
+        }.to raise_error(ArgumentError, /Given invalid module_set/)
+      end
+    end
   end
 
   describe '#trace' do
     describe 'when tracing script' do
       # @param path [String]
       # @return [DiverDown::Definition]
-      def trace_fixture(path, module_set: [], target_files: nil, ignored_method_ids: [], filter_method_id_path: nil, definition_group: nil)
+      def trace_fixture(path, module_set: {}, target_files: nil, ignored_method_ids: [], filter_method_id_path: nil, definition_group: nil)
         # NOTE: Script need to define .run method
         script = fixture_path(path)
         load script, AntipollutionModule
@@ -63,11 +73,13 @@ RSpec.describe DiverDown::Trace::Tracer do
       it 'traces tracer_module.rb' do
         definition = trace_fixture(
           'tracer_module.rb',
-          module_set: [
-            'AntipollutionModule::A',
-            'AntipollutionModule::B',
-            'AntipollutionModule::C',
-          ]
+          module_set: {
+            modules: [
+              'AntipollutionModule::A',
+              'AntipollutionModule::B',
+              'AntipollutionModule::C',
+            ],
+          }
         )
 
         expect(definition.to_h).to match(fill_default(
@@ -115,11 +127,13 @@ RSpec.describe DiverDown::Trace::Tracer do
       it 'traces tracer_module.rb with definition_group' do
         definition = trace_fixture(
           'tracer_module.rb',
-          module_set: [
-            'AntipollutionModule::A',
-            'AntipollutionModule::B',
-            'AntipollutionModule::C',
-          ],
+          module_set: {
+            modules: [
+              'AntipollutionModule::A',
+              'AntipollutionModule::B',
+              'AntipollutionModule::C',
+            ],
+          },
           definition_group: 'x'
         )
 
@@ -169,11 +183,13 @@ RSpec.describe DiverDown::Trace::Tracer do
       it 'traces tracer_module.rb with target_files' do
         definition = trace_fixture(
           'tracer_module.rb',
-          module_set: [
-            'AntipollutionModule::A',
-            'AntipollutionModule::B',
-            'AntipollutionModule::C',
-          ],
+          module_set: {
+            modules: [
+              'AntipollutionModule::A',
+              'AntipollutionModule::B',
+              'AntipollutionModule::C',
+            ],
+          },
           target_files: []
         )
 
@@ -196,12 +212,14 @@ RSpec.describe DiverDown::Trace::Tracer do
       it 'traces tracer_class.rb' do
         definition = trace_fixture(
           'tracer_class.rb',
-          module_set: [
-            'AntipollutionModule::A',
-            'AntipollutionModule::B',
-            'AntipollutionModule::C',
-            'AntipollutionModule::D',
-          ]
+          module_set: {
+            modules: [
+              'AntipollutionModule::A',
+              'AntipollutionModule::B',
+              'AntipollutionModule::C',
+              'AntipollutionModule::D',
+            ],
+          }
         )
 
         expect(definition.to_h).to match(fill_default(
@@ -268,12 +286,14 @@ RSpec.describe DiverDown::Trace::Tracer do
       it 'traces tracer_class.rb with filter path' do
         definition = trace_fixture(
           'tracer_class.rb',
-          module_set: [
-            'AntipollutionModule::A',
-            'AntipollutionModule::B',
-            'AntipollutionModule::C',
-            'AntipollutionModule::D',
-          ],
+          module_set: {
+            modules: [
+              'AntipollutionModule::A',
+              'AntipollutionModule::B',
+              'AntipollutionModule::C',
+              'AntipollutionModule::D',
+            ],
+          },
           filter_method_id_path: ->(path) {
             path.gsub(fixture_path(''), '')
           }
@@ -286,12 +306,14 @@ RSpec.describe DiverDown::Trace::Tracer do
       it 'traces tracer_instance.rb' do
         definition = trace_fixture(
           'tracer_instance.rb',
-          module_set: [
-            'AntipollutionModule::A',
-            'AntipollutionModule::B',
-            'AntipollutionModule::C',
-            'AntipollutionModule::D',
-          ]
+          module_set: {
+            modules: [
+              'AntipollutionModule::A',
+              'AntipollutionModule::B',
+              'AntipollutionModule::C',
+              'AntipollutionModule::D',
+            ],
+          }
         )
 
         expect(definition.to_h).to match(fill_default(
@@ -372,10 +394,12 @@ RSpec.describe DiverDown::Trace::Tracer do
       it 'traces tracer_subclass.rb' do
         definition = trace_fixture(
           'tracer_subclass.rb',
-          module_set: [
-            'AntipollutionModule::A',
-            'AntipollutionModule::D',
-          ]
+          module_set: {
+            modules: [
+              'AntipollutionModule::A',
+              'AntipollutionModule::D',
+            ],
+          }
         )
 
         expect(definition.to_h).to match(fill_default(
@@ -460,10 +484,12 @@ RSpec.describe DiverDown::Trace::Tracer do
 
         definition = trace_fixture(
           'tracer_separated_file.rb',
-          module_set: [
-            '::A',
-            '::C',
-          ],
+          module_set: {
+            modules: [
+              '::A',
+              '::C',
+            ],
+          },
           target_files: [
             fixture_path('tracer_separated_file.rb'),
           ]
@@ -502,12 +528,14 @@ RSpec.describe DiverDown::Trace::Tracer do
           ignored_method_ids: [
             'AntipollutionModule::B.class_call',
           ],
-          module_set: [
-            'AntipollutionModule::A',
-            'AntipollutionModule::B',
-            'AntipollutionModule::C',
-            'AntipollutionModule::D',
-          ],
+          module_set: {
+            modules: [
+              'AntipollutionModule::A',
+              'AntipollutionModule::B',
+              'AntipollutionModule::C',
+              'AntipollutionModule::D',
+            ],
+          },
           target_files: [
             fixture_path('tracer_ignored_call_stack.rb'),
           ]
@@ -542,10 +570,12 @@ RSpec.describe DiverDown::Trace::Tracer do
       it 'traces tracer_deep_stack.rb' do
         definition = trace_fixture(
           'tracer_deep_stack.rb',
-          module_set: [
-            'AntipollutionModule::A',
-            'AntipollutionModule::D',
-          ]
+          module_set: {
+            modules: [
+              'AntipollutionModule::A',
+              'AntipollutionModule::D',
+            ],
+          }
         )
 
         expect(definition.to_h).to match(fill_default(
@@ -595,10 +625,12 @@ RSpec.describe DiverDown::Trace::Tracer do
       #
       #     tracer = described_class.new(
       #       title: 'title',
-      #       module_set: [
-      #         AntipollutionModule::A,
-      #         AntipollutionModule::D,
-      #       ]
+      #       module_set: {
+      #         modules: [
+      #           AntipollutionModule::A,
+      #           AntipollutionModule::D,
+      #         ]
+      #       }
       #     )
       #
       #     tracer.trace(title: '') do


### PR DESCRIPTION
Add new method `#new_session` to analyze ruby code without block.

```
tracer = DiverDown::Trace::Tracer.new
session = tracer.new_session
session.start

do_something

session.stop
definition = session.definition
```

---

Other small changes:
- `module_set:` requires Hash.