### PR TITLE
Moved concerns about the ignored call stack into CallStack.

### DIFF
--- a/lib/diver_down/trace/call_stack.rb
+++ b/lib/diver_down/trace/call_stack.rb
@@ -12,6 +12,7 @@ module DiverDown
       attr_reader :stack_size
 
       def initialize
+        @ignored_stack_size = nil
         @stack_size = 0
         @stack = {}
       end
@@ -28,9 +29,17 @@ module DiverDown
 
       # @param context [Object, nil] User defined stack context.
       # @return [void]
-      def push(context = nil)
+      def push(context = nil, ignored: false)
         @stack_size += 1
         @stack[@stack_size] = context unless context.nil?
+        @ignored_stack_size ||= @stack_size if ignored
+      end
+
+      # If a stack is not already a tracing target, some conditions are unnecessary so that it can be easily ignored.
+      #
+      # @return [Boolean]
+      def ignored?
+        !@ignored_stack_size.nil?
       end
 
       # @return [void]
@@ -38,6 +47,7 @@ module DiverDown
         raise StackEmptyError if @stack_size.zero?
 
         @stack.delete(@stack_size) if @stack.key?(@stack_size)
+        @ignored_stack_size = nil if @ignored_stack_size && @ignored_stack_size == @stack_size
         @stack_size -= 1
       end
     end

--- a/spec/diver_down/trace/call_stack_spec.rb
+++ b/spec/diver_down/trace/call_stack_spec.rb
@@ -38,6 +38,24 @@ RSpec.describe DiverDown::Trace::CallStack do
 
         expect(stack.stack).to eq([])
       end
+
+      context 'with _ignored: true' do
+        it 'marks current stack as ignored' do
+          stack = described_class.new
+
+          stack.push
+          stack.push(ignored: true)
+          stack.push
+
+          expect(stack.ignored?).to be(true)
+          stack.pop
+          expect(stack.ignored?).to be(true)
+          stack.pop
+          expect(stack.ignored?).to be(false)
+          stack.pop
+          expect(stack.ignored?).to be(false)
+        end
+      end
     end
 
     describe '#empty?' do

--- a/spec/diver_down/trace/tracer_spec.rb
+++ b/spec/diver_down/trace/tracer_spec.rb
@@ -686,12 +686,11 @@ RSpec.describe DiverDown::Trace::Tracer do
       #     antipollution_environment = AntipollutionKlass.allocate
       #
       #     tracer = described_class.new(
-      #       title: 'title',
       #       module_set: {
       #         modules: [
       #           AntipollutionModule::A,
       #           AntipollutionModule::D,
-      #         ]
+      #         ],
       #       }
       #     )
       #


### PR DESCRIPTION
If method is contained in `ignored_method_ids`, TracePoint should be returned early to speed up processing.
The current processing will be kept as is, but the concern will be moved to `CallStack` to simplify it.