### PR TITLE
Support dry gem

### DIFF
--- a/lib/diver_down/helper.rb
+++ b/lib/diver_down/helper.rb
@@ -28,7 +28,11 @@ module DiverDown
     # @return [Module, Class]
     def self.resolve_module(obj)
       if module?(obj) # Do not call method of this
-        resolve_singleton_class(obj)
+        if module_subclass?(obj)
+          obj.class
+        else
+          resolve_singleton_class(obj)
+        end
       else
         k = INSTANCE_CLASS_QUERY.bind_call(obj)
         resolve_singleton_class(k)
@@ -61,6 +65,13 @@ module DiverDown
     # @return [Module]
     def self.constantize(str)
       ::ActiveSupport::Inflector.constantize(str)
+    end
+
+    # FIXME: I don't know the best way to determine which class inherits from Module.
+    # @return [Boolean]
+    def self.module_subclass?(mod)
+      mod.ancestors.size == 1 &&
+        mod.class < Module
     end
   end
 end

--- a/lib/diver_down/trace/session.rb
+++ b/lib/diver_down/trace/session.rb
@@ -55,7 +55,7 @@ module DiverDown
 
             mod = DiverDown::Helper.resolve_module(tp.self)
 
-            if mod.nil?
+            unless mod
               call_stack.push
               next
             end

--- a/spec/diver_down/helper_spec.rb
+++ b/spec/diver_down/helper_spec.rb
@@ -73,6 +73,19 @@ RSpec.describe DiverDown::Helper do
         expect(described_class.resolve_module(mod)).to eq(mod)
       end
 
+      it 'returns class given inherited module' do
+        class A < ::Module
+          # @return [nil]
+          def name
+            raise 'This method should not be called'
+          end
+        end
+
+        expect(described_class.resolve_module(A.new)).to eq(A)
+      ensure
+        Object.send(:remove_const, :A)
+      end
+
       it 'returns string given class' do
         klass = Class.new do
           def self.name


### PR DESCRIPTION
The `dry` gem uses a module that inherits from Module. This class must be parsed properly or an error will occur.