### PR TITLE
Render unclassified sources count

### DIFF
--- a/frontend/models/definition.ts
+++ b/frontend/models/definition.ts
@@ -3,4 +3,5 @@ export type Definition = {
   definitionGroup: string | null
   title: string
   sourcesCount: number
+  unclassifiedSourcesCount: number
 }

--- a/frontend/pages/DefinitionList/components/DefinitionList/List.tsx
+++ b/frontend/pages/DefinitionList/components/DefinitionList/List.tsx
@@ -82,10 +82,13 @@ export const List = forwardRef<HTMLLIElement, Props>((props, ref) => {
           }
 
           const isSelected = selectedDefinitionIds.includes(definition.id)
+          const countLabel = definition.unclassifiedSourcesCount === 0 ?
+            `(${definition.sourcesCount})` :
+            `(${definition.unclassifiedSourcesCount}/${definition.sourcesCount})`
 
           items.push({
             key: `definition-${definition.id}`,
-            title: `(${definition.sourcesCount}) ${definition.title}`,
+            title: `${countLabel} ${definition.title}`,
             isSelected,
             onClick: onClickDefinition,
             prefix: (

--- a/frontend/repositories/definitionListRepository.ts
+++ b/frontend/repositories/definitionListRepository.ts
@@ -13,6 +13,7 @@ type DefinitionReponse = {
   definition_group: string | null
   title: string
   sources_count: number
+  unclassified_sources_count: number
 }
 
 type DefinitionsResponse = {
@@ -49,6 +50,7 @@ export const useDefinitionList = (
       definitionGroup: definition.definition_group,
       title: definition.title,
       sourcesCount: definition.sources_count,
+      unclassifiedSourcesCount: definition.unclassified_sources_count,
     }))
   }, [])
 

--- a/lib/diver_down/web/action.rb
+++ b/lib/diver_down/web/action.rb
@@ -131,6 +131,7 @@ module DiverDown
               definition_group: definition.definition_group,
               title: definition.title,
               sources_count: definition.sources.size,
+              unclassified_sources_count: definition.sources.reject { @module_store.include?(_1.source_name) }.size,
             }
           end,
           pagination: pagination.to_h

--- a/lib/diver_down/web/module_store.rb
+++ b/lib/diver_down/web/module_store.rb
@@ -29,6 +29,12 @@ module DiverDown
         @store[source_name] || BLANK_ARRAY
       end
 
+      # @param source_name [String]
+      # @return [Boolean]
+      def include?(source_name)
+        get(source_name).any?
+      end
+
       # @return [Hash]
       def to_h
         sorted_store = {}

--- a/spec/diver_down/web/module_store_spec.rb
+++ b/spec/diver_down/web/module_store_spec.rb
@@ -34,6 +34,20 @@ RSpec.describe DiverDown::Web::ModuleStore do
       end
     end
 
+    describe '#include?' do
+      it 'returns bool' do
+        tempfile = Tempfile.new(['test', '.yaml'])
+        instance = described_class.new(tempfile.path)
+
+        instance.set('a.rb', [])
+        instance.set('b.rb', ['A'])
+
+        expect(instance.include?('a.rb')).to be(false)
+        expect(instance.include?('b.rb')).to be(true)
+        expect(instance.include?('c.rb')).to be(false)
+      end
+    end
+
     describe '#flush' do
       it 'writes modules to path' do
         tempfile = Tempfile.new(['test', '.yaml'])

--- a/spec/diver_down/web_spec.rb
+++ b/spec/diver_down/web_spec.rb
@@ -58,16 +58,25 @@ RSpec.describe DiverDown::Web do
       })
     end
 
-    it 'returns definition if store has one definition' do
-      definition = DiverDown::Definition.new(
-        title: 'title',
+    it 'returns definition if store has some definition' do
+      definition_1 = DiverDown::Definition.new(
+        title: 'title1',
         sources: [
           DiverDown::Definition::Source.new(
             source_name: 'a.rb'
           ),
         ]
       )
-      store.set(definition)
+      definition_2 = DiverDown::Definition.new(
+        title: 'title2',
+        sources: [
+          DiverDown::Definition::Source.new(
+            source_name: 'b.rb'
+          ),
+        ]
+      )
+      store.set(definition_1, definition_2)
+      module_store.set('a.rb', ['A'])
 
       get '/api/definitions.json'
 
@@ -76,15 +85,22 @@ RSpec.describe DiverDown::Web do
         'definitions' => [
           {
             'id' => 1,
-            'title' => 'title',
+            'title' => 'title1',
             'definition_group' => nil,
             'sources_count' => 1,
+            'unclassified_sources_count' => 0,
+          }, {
+            'id' => 2,
+            'title' => 'title2',
+            'definition_group' => nil,
+            'sources_count' => 1,
+            'unclassified_sources_count' => 1,
           },
         ],
         'pagination' => {
           'current_page' => 1,
           'total_pages' => 1,
-          'total_count' => 1,
+          'total_count' => 2,
           'per' => 100,
         },
       })


### PR DESCRIPTION
<img width="281" alt="スクリーンショット 2024-05-13 10 18 13" src="https://github.com/alpaca-tc/diver_down/assets/1688137/572c599e-11f0-4a30-a3ba-49c95fd08f0a">

Display the number of unclassified modules to make it easier to proceed with jobs.