### PR TITLE
bugfix: Unescape escaped module names

### DIFF
--- a/lib/diver_down/web.rb
+++ b/lib/diver_down/web.rb
@@ -53,7 +53,7 @@ module DiverDown
       in ['GET', %r{\A/api/modules\.json\z}]
         action.modules
       in ['GET', %r{\A/api/modules/(?<module_names>.+)\.json\z}]
-        module_names = Regexp.last_match[:module_names].split('/')
+        module_names = CGI.unescape(Regexp.last_match[:module_names]).split('/')
         action.module(module_names)
       in ['GET', %r{\A/api/definitions/(?<bit_id>\d+)\.json\z}]
         bit_id = Regexp.last_match[:bit_id].to_i

--- a/spec/diver_down/web_spec.rb
+++ b/spec/diver_down/web_spec.rb
@@ -455,6 +455,42 @@ RSpec.describe DiverDown::Web do
         ],
       })
     end
+
+    it 'returns module if module_name is escaped' do
+      definition = DiverDown::Definition.new(
+        title: 'title',
+        sources: [
+          DiverDown::Definition::Source.new(
+            source_name: 'a.rb'
+          ),
+        ]
+      )
+
+      ids = store.set(definition)
+      module_store.set('a.rb', ['グローバル'])
+
+      get "/api/modules/#{CGI.escape('グローバル')}.json"
+
+      expect(last_response.status).to eq(200)
+      expect(JSON.parse(last_response.body)).to eq({
+        'modules' => [
+          {
+            'module_name' => 'グローバル',
+          },
+        ],
+        'sources' => [
+          {
+            'source_name' => 'a.rb',
+          },
+        ],
+        'related_definitions' => [
+          {
+            'id' => ids[0],
+            'title' => 'title',
+          },
+        ],
+      })
+    end
   end
 
   describe 'GET /api/definitions/:id.json' do


### PR DESCRIPTION
Fixed to parse module names when strings containing Japanese characters are passed in URLs.