### PR TITLE
Change definition sources width 400 -> 600

### DIFF
--- a/frontend/pages/DefinitionList/Show.tsx
+++ b/frontend/pages/DefinitionList/Show.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 
 import { Loading } from '@/components/Loading'
-import { Aside, Section, Sidebar, Stack } from '@/components/ui'
+import { Aside, Button, Section, Sidebar, Stack } from '@/components/ui'
 import { color } from '@/constants/theme'
 import { useBitIdHash } from '@/hooks/useBitIdHash'
 import { useLocalStorage } from '@/hooks/useLocalStorage'

--- a/frontend/pages/DefinitionList/components/DefinitionSources/DefinitionSources.tsx
+++ b/frontend/pages/DefinitionList/components/DefinitionSources/DefinitionSources.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 import { Link } from '@/components/Link'
 import {
   Aside,
-  Button,
   Cluster,
   EmptyTableBody,
   FaCircleInfoIcon,
@@ -67,7 +66,7 @@ export const DefinitionSources: FC<Props> = ({ combinedDefinition, mutateCombine
     <WrapperAside>
       <TableWrapper>
         <TableReel>
-          <StyledTable fixedHead>
+          <Table fixedHead>
             <thead>
               <tr>
                 <Th sort={sortState.key === 'sourceName' ? sortState.sort : 'none'} onSort={() => setNextSortType('sourceName')}>
@@ -170,7 +169,7 @@ export const DefinitionSources: FC<Props> = ({ combinedDefinition, mutateCombine
                 ))}
               </tbody>
             )}
-          </StyledTable>
+          </Table>
         </TableReel>
       </TableWrapper>
     </WrapperAside>
@@ -182,7 +181,8 @@ const WrapperAside = styled(Aside)`
   padding: 0;
   height: inherit;
   overflow-y: scroll;
-  max-width: 400px;
+  max-width: 600px;
+  border-left: 1px ${color.BORDER} solid;
 
   &&& {
     margin-top: 0;
@@ -200,8 +200,4 @@ const Transparent = styled.span`
 
 const FixedWidthMemo = styled(Cluster)`
   width: 4em;
-`
-
-const StyledTable = styled(Table)`
-  border-left: 1px ${color.BORDER} solid;
 `

--- a/frontend/pages/Modules/Show.tsx
+++ b/frontend/pages/Modules/Show.tsx
@@ -66,9 +66,7 @@ export const Show: React.FC = () => {
                                 <Link to={path.sources.show(source.sourceName)}>{source.sourceName}</Link>
                               </Td>
                               <Td>
-                                <Text>
-                                  {source.memo}
-                                </Text>
+                                <Text>{source.memo}</Text>
                               </Td>
                             </tr>
                           ))}


### PR DESCRIPTION
The source list displayed on the right side now seems narrower in width with the addition of the memo column.
The width was changed from 400 to 600.