### PR TITLE
Support `AnonymousController` in rspec-rails

### DIFF
--- a/spec/diver_down/trace/tracer_spec.rb
+++ b/spec/diver_down/trace/tracer_spec.rb
@@ -744,6 +744,44 @@ RSpec.describe DiverDown::Trace::Tracer do
         ))
       end
 
+      it 'traces tracer_anonymous_class.rb' do
+        definition = trace_fixture(
+          'tracer_anonymous_class.rb',
+          module_set: {
+            modules: [
+              'AntipollutionModule::A',
+              'AntipollutionModule::B',
+            ],
+          }
+        )
+
+        expect(definition.to_h).to match(fill_default(
+          title: 'title',
+          sources: [
+            {
+              source_name: 'AntipollutionModule::A',
+              dependencies: [
+                {
+                  source_name: 'AntipollutionModule::B',
+                  method_ids: [
+                    {
+                      name: 'should_be_traced',
+                      context: 'class',
+                      paths: [
+                        match(/tracer_anonymous_class\.rb:\d+/),
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              source_name: 'AntipollutionModule::B',
+            },
+          ]
+        ))
+      end
+
       it 'traces wrapped in the module to be target before starting the trace' do
         dir = Dir.mktmpdir
         File.write(File.join(dir, 'a.rb'), <<~RUBY)

--- a/spec/fixtures/tracer_anonymous_class.rb
+++ b/spec/fixtures/tracer_anonymous_class.rb
@@ -1,0 +1,29 @@
+def run
+  # like AnonymousController in rspec-rails
+  anonymous_class = Class.new(A) do
+    def self.name
+      "Anonymous"
+    end
+
+    # defined as anonymous class
+    def self.should_be_ignored
+      B.should_be_ignored
+    end
+  end
+
+  anonymous_class.should_be_ignored
+  anonymous_class.should_be_traced
+end
+
+class A
+  # defined as non-anonymous class
+  def self.should_be_traced
+    B.should_be_traced
+  end
+end
+
+class B
+  def self.should_be_traced = nil
+
+  def self.should_be_ignored = nil
+end


### PR DESCRIPTION
Exclude anonymous controllers created for testing.