### PR TITLE
Brighten node when cursor on source

### DIFF
--- a/frontend/context/HoverMetadataContext.ts
+++ b/frontend/context/HoverMetadataContext.ts
@@ -1,0 +1,12 @@
+import { DotMetadata } from '@/models/combinedDefinition'
+import React from 'react'
+
+export type HoverDotMetadataContextProps = {
+  hoverDotMetadata: DotMetadata | null
+  setHoverDotMetadata: React.Dispatch<React.SetStateAction<DotMetadata | null>>
+}
+
+export const HoverDotMetadataContext = React.createContext<HoverDotMetadataContextProps>({
+  hoverDotMetadata: null,
+  setHoverDotMetadata: () => {},
+})

--- a/frontend/pages/DefinitionList/Show.tsx
+++ b/frontend/pages/DefinitionList/Show.tsx
@@ -17,6 +17,8 @@ import { MetadataDialog } from './components/MetadataDialog'
 import type { DialogProps } from './components/dialog'
 import { RecentModulesContext } from '@/context/RecentModulesContext'
 import { Module } from '@/models/module'
+import { HoverDotMetadataContext } from '@/context/HoverMetadataContext'
+import { DotMetadata } from '@/models/combinedDefinition'
 
 export const Show: React.FC = () => {
   const [selectedDefinitionIds, setSelectedDefinitionIds] = useBitIdHash()
@@ -26,6 +28,7 @@ export const Show: React.FC = () => {
     concentrate: false,
     onlyModule: false,
   })
+  const [hoverDotMetadata, setHoverDotMetadata] = useState<DotMetadata | null>(null)
   const {
     data: combinedDefinition,
     isLoading,
@@ -40,45 +43,47 @@ export const Show: React.FC = () => {
   return (
     <Wrapper>
       <RecentModulesContext.Provider value={{ recentModules, setRecentModules }}>
-        <StyledSidebar contentsMinWidth="0px" gap={0}>
-          <StyledAside>
-            <DefinitionList selectedDefinitionIds={selectedDefinitionIds} setSelectedDefinitionIds={setSelectedDefinitionIds} />
-          </StyledAside>
-          <StyledSection>
-            <MetadataDialog
-              isOpen={visibleDialog?.type === 'metadataDialog'}
-              dotMetadata={visibleDialog?.type === 'metadataDialog' ? visibleDialog.metadata : null}
-              top={visibleDialog?.type === 'metadataDialog' ? visibleDialog.top : 0}
-              left={visibleDialog?.type === 'metadataDialog' ? visibleDialog.left : 0}
-              onClose={onCloseDialog}
-              setVisibleDialog={setVisibleDialog}
-              mutateCombinedDefinition={mutateCombinedDefinition}
-            />
-            {isLoading ? (
-              <CenterStack>
-                <Loading text="Loading..." alt="Loading" />
-              </CenterStack>
-            ) : !combinedDefinition ? (
-              <CenterStack>
-                <p>No data</p>
-              </CenterStack>
-            ) : (
-              <StyledStack>
-                <DefinitionGraph
-                  combinedDefinition={combinedDefinition}
-                  graphOptions={graphOptions}
-                  setGraphOptions={setGraphOptions}
-                  visibleDialog={visibleDialog}
-                  setVisibleDialog={setVisibleDialog}
-                />
-                <StyledDefinitionSources
-                  combinedDefinition={combinedDefinition}
-                  mutateCombinedDefinition={mutateCombinedDefinition}
-                />
-              </StyledStack>
-            )}
-          </StyledSection>
-        </StyledSidebar>
+        <HoverDotMetadataContext.Provider value={{ hoverDotMetadata, setHoverDotMetadata }}>
+          <StyledSidebar contentsMinWidth="0px" gap={0}>
+            <StyledAside>
+              <DefinitionList selectedDefinitionIds={selectedDefinitionIds} setSelectedDefinitionIds={setSelectedDefinitionIds} />
+            </StyledAside>
+            <StyledSection>
+              <MetadataDialog
+                isOpen={visibleDialog?.type === 'metadataDialog'}
+                dotMetadata={visibleDialog?.type === 'metadataDialog' ? visibleDialog.metadata : null}
+                top={visibleDialog?.type === 'metadataDialog' ? visibleDialog.top : 0}
+                left={visibleDialog?.type === 'metadataDialog' ? visibleDialog.left : 0}
+                onClose={onCloseDialog}
+                setVisibleDialog={setVisibleDialog}
+                mutateCombinedDefinition={mutateCombinedDefinition}
+              />
+              {isLoading ? (
+                <CenterStack>
+                  <Loading text="Loading..." alt="Loading" />
+                </CenterStack>
+              ) : !combinedDefinition ? (
+                <CenterStack>
+                  <p>No data</p>
+                </CenterStack>
+              ) : (
+                <StyledStack>
+                  <DefinitionGraph
+                    combinedDefinition={combinedDefinition}
+                    graphOptions={graphOptions}
+                    setGraphOptions={setGraphOptions}
+                    visibleDialog={visibleDialog}
+                    setVisibleDialog={setVisibleDialog}
+                  />
+                  <StyledDefinitionSources
+                    combinedDefinition={combinedDefinition}
+                    mutateCombinedDefinition={mutateCombinedDefinition}
+                  />
+                </StyledStack>
+              )}
+            </StyledSection>
+          </StyledSidebar>
+        </HoverDotMetadataContext.Provider>
       </RecentModulesContext.Provider>
     </Wrapper>
   )


### PR DESCRIPTION
When the cursor on a source, the specific source displaying in a color that is easy to recognize.
This is because it is difficult to find where a particular source is displayed on the graph.