### PR TITLE
Load `tempfile` explicitly

### DIFF
--- a/exe/diver_down_web
+++ b/exe/diver_down_web
@@ -6,6 +6,7 @@ require 'rack/contrib'
 require 'diver_down'
 require 'diver_down-web'
 require 'optparse'
+require 'tempfile'
 
 options = {}
 option_parser = OptionParser.new do |opts|


### PR DESCRIPTION
# Problem

This gem raises the following error when `--metadata` option is not specified.

```
bundler: failed to load command: diver_down_web (/app/vendor/bundle/ruby/3.3.0/bin/diver_down_web)
/app/vendor/bundle/ruby/3.3.0/gems/diver_down-0.0.1.alpha16/exe/diver_down_web:41:in `<top (required)>': uninitialized constant Tempfile (NameError)

    metadata: DiverDown::Web::Metadata.new(options[:metadata] || Tempfile.new(['metadata', '.yaml']).path)
                                                                 ^^^^^^^^
        from /app/vendor/bundle/ruby/3.3.0/bin/diver_down_web:25:in `load'
        from /app/vendor/bundle/ruby/3.3.0/bin/diver_down_web:25:in `<top (required)>'
        from /app/vendor/bundle/ruby/3.3.0/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `load'
        from /app/vendor/bundle/ruby/3.3.0/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `kernel_load'
        from /app/vendor/bundle/ruby/3.3.0/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:23:in `run'
        from /app/vendor/bundle/ruby/3.3.0/gems/bundler-2.3.26/lib/bundler/cli.rb:486:in `exec'
        from /app/vendor/bundle/ruby/3.3.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        from /app/vendor/bundle/ruby/3.3.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /app/vendor/bundle/ruby/3.3.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
        from /app/vendor/bundle/ruby/3.3.0/gems/bundler-2.3.26/lib/bundler/cli.rb:31:in `dispatch'
        from /app/vendor/bundle/ruby/3.3.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
        from /app/vendor/bundle/ruby/3.3.0/gems/bundler-2.3.26/lib/bundler/cli.rb:25:in `start'
        from /app/vendor/bundle/ruby/3.3.0/gems/bundler-2.3.26/exe/bundle:48:in `block in <top (required)>'
        from /app/vendor/bundle/ruby/3.3.0/gems/bundler-2.3.26/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
        from /app/vendor/bundle/ruby/3.3.0/gems/bundler-2.3.26/exe/bundle:36:in `<top (required)>'
        from /usr/local/bin/bundle:25:in `load'
        from /usr/local/bin/bundle:25:in `<main>'
```

# Solution


Load `tempfile` explicitly.


----

Probably this problem has been introduced by this commit 3397d9d0f77af4052630feb4d4d36d8de3c2a3fb.
Previously WEBrick loaded `tempfile` library, but `require`ing webrick has been removed. So it cannot find `Tempfile` constant.