### PR TITLE
Make the tracer thread-safe

### DIFF
--- a/lib/diver_down/trace/session.rb
+++ b/lib/diver_down/trace/session.rb
@@ -38,12 +38,14 @@ module DiverDown
       private
 
       def build_trace_point
-        call_stack = DiverDown::Trace::CallStack.new
+        call_stacks = {}
 
         TracePoint.new(*DiverDown::Trace::Tracer.trace_events) do |tp|
           # Skip the trace of the library itself
           next if tp.path&.start_with?(DiverDown::LIB_DIR)
           next if TracePoint == tp.defined_class
+
+          call_stack = call_stacks[Thread.current] ||= DiverDown::Trace::CallStack.new
 
           case tp.event
           when :b_call


### PR DESCRIPTION
# Problem


This gem raises `DiverDown::Trace::CallStack::StackEmptyError` while investigating a Rails application.


I assumed the cause is thread-unsafe code, and I made a small code to reproduce it.
This code raises the `StackEmptyError` (it is not 100% occurred as with most thread-unsafe problems).

```ruby
require 'diver_down-trace'

class M
  def f
    N.new.g
  end
end

class N
  def g
  end
end

defn = DiverDown::Trace::Tracer.new(module_set: { modules: [M] }).trace do
  10.times.map do
    Thread.new { 10_000.times { M.new.f } }
  end.each(&:join)
end

pp defn.to_h
```

```ruby
$ ruby -Ilib/ tmp/test.rb
#<Thread:0x000000011ff92f48 tmp/test.rb:16 run> terminated with exception (report_on_exception is true):
/Users/kuwabara.masataka/ghq/github.com/alpaca-tc/diver_down/lib/diver_down/trace/call_stack.rb:52:in 'DiverDown::Trace::CallStack#pop': DiverDown::Trace::CallStack::StackEmptyError (DiverDown::Trace::CallStack::StackEmptyError)
        from /Users/kuwabara.masataka/ghq/github.com/alpaca-tc/diver_down/lib/diver_down/trace/session.rb:52:in 'block in DiverDown::Trace::Session#build_trace_point'
        from tmp/test.rb:16:in 'block (3 levels) in <main>'
/Users/kuwabara.masataka/ghq/github.com/alpaca-tc/diver_down/lib/diver_down/trace/call_stack.rb:52:in 'DiverDown::Trace::CallStack#pop': DiverDown::Trace::CallStack::StackEmptyError (DiverDown::Trace::CallStack::StackEmptyError)
        from /Users/kuwabara.masataka/ghq/github.com/alpaca-tc/diver_down/lib/diver_down/trace/session.rb:52:in 'block in DiverDown::Trace::Session#build_trace_point'
        from tmp/test.rb:16:in 'block (3 levels) in <main>'

```



# Solution


This is because several threads update the same `DiverDown::Trace::CallStack` object.
So I separated the call stack object for each thread. 