### PR TITLE
Add support for ignoring single method calls in the trace

### DIFF
--- a/lib/diver_down/trace/session.rb
+++ b/lib/diver_down/trace/session.rb
@@ -66,9 +66,12 @@ module DiverDown
               next
             end
 
-            if !@ignored_method_ids.nil? && @ignored_method_ids.ignored?(mod, DiverDown::Helper.module?(tp.self), tp.method_id)
-              # If this method is ignored, the call stack is ignored until the method returns.
-              call_stack.push(ignored: true)
+            ignored = @ignored_method_ids.ignored(mod, DiverDown::Helper.module?(tp.self), tp.method_id) if @ignored_method_ids
+
+            if ignored
+              # If ignored is :all, the call stack is ignored until the method returns.
+              # If ignored is :single, the call stack is ignored only current call.
+              call_stack.push(ignored: ignored == :all)
               next
             end
 

--- a/lib/diver_down/trace/tracer.rb
+++ b/lib/diver_down/trace/tracer.rb
@@ -24,7 +24,7 @@ module DiverDown
 
       # @param module_set [DiverDown::Trace::ModuleSet, Array<Module, String>]
       # @param caller_paths [Array<String>, nil] if nil, trace all files
-      # @param ignored_method_ids [Array<String>]
+      # @param ignored_method_ids [Hash{ String => Symbol }, nil]
       # @param filter_method_id_path [#call, nil] filter method_id.path
       # @param module_set [DiverDown::Trace::ModuleSet, nil] for optimization
       def initialize(module_set: {}, caller_paths: nil, ignored_method_ids: nil, filter_method_id_path: nil)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@hpcc-js/wasm": "^2.16.2",
+    "@hpcc-js/wasm": "2.16.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-intersection-observer": "^9.10.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@hpcc-js/wasm':
-        specifier: ^2.16.2
+        specifier: 2.16.2
         version: 2.16.2
       react:
         specifier: ^18.3.1

--- a/spec/diver_down/trace/ignored_method_ids_spec.rb
+++ b/spec/diver_down/trace/ignored_method_ids_spec.rb
@@ -2,29 +2,41 @@
 
 RSpec.describe DiverDown::Trace::IgnoredMethodIds do
   describe 'InstanceMethods' do
-    describe '#ignored?' do
+    describe '#ignored' do
       it 'returns false if ignored_methods are blank' do
         stub_const('A', Class.new)
 
-        ignored_method = described_class.new([])
+        ignored_method = described_class.new({})
 
-        expect(ignored_method.ignored?(A, true, 'new')).to be(false)
+        expect(ignored_method.ignored(A, true, 'new')).to be(false)
       end
 
-      it 'returns true if class is matched' do
+      it 'returns :all if class is ignored as :all' do
         stub_const('A', Class.new)
         stub_const('B', Class.new)
         stub_const('C', Class.new(A))
 
         ignored_method = described_class.new(
-          [
-            'A',
-          ]
+          'A' => :all
         )
 
-        expect(ignored_method.ignored?(A, true, :new)).to be(true)
-        expect(ignored_method.ignored?(B, true, :new)).to be(false)
-        expect(ignored_method.ignored?(C, true, :new)).to be(true)
+        expect(ignored_method.ignored(A, true, :new)).to be(:all)
+        expect(ignored_method.ignored(B, true, :new)).to be(false)
+        expect(ignored_method.ignored(C, true, :new)).to be(:all)
+      end
+
+      it 'returns :single if class is ignored as :single' do
+        stub_const('A', Class.new)
+        stub_const('B', Class.new)
+        stub_const('C', Class.new(A))
+
+        ignored_method = described_class.new(
+          'A' => :single
+        )
+
+        expect(ignored_method.ignored(A, true, :new)).to be(:single)
+        expect(ignored_method.ignored(B, true, :new)).to be(false)
+        expect(ignored_method.ignored(C, true, :new)).to be(:single)
       end
 
       it 'does not lookup the ancestors if module given because of the complexity of implementation' do
@@ -33,14 +45,12 @@ RSpec.describe DiverDown::Trace::IgnoredMethodIds do
         stub_const('C', Module.new.tap { _1.extend(A) })
 
         ignored_method = described_class.new(
-          [
-            'A.name',
-          ]
+          'A.name' => :all
         )
 
-        expect(ignored_method.ignored?(A, true, :name)).to be(true)
-        expect(ignored_method.ignored?(B, true, :name)).to be(false)
-        expect(ignored_method.ignored?(C, true, :name)).to be(false)
+        expect(ignored_method.ignored(A, true, :name)).to be(:all)
+        expect(ignored_method.ignored(B, true, :name)).to be(false)
+        expect(ignored_method.ignored(C, true, :name)).to be(false)
       end
 
       it 'returns true if class method is matched' do
@@ -49,14 +59,12 @@ RSpec.describe DiverDown::Trace::IgnoredMethodIds do
         stub_const('C', Class.new(A))
 
         ignored_method = described_class.new(
-          [
-            'A.new',
-          ]
+          'A.new' => :all
         )
 
-        expect(ignored_method.ignored?(A, true, :new)).to be(true)
-        expect(ignored_method.ignored?(B, true, :new)).to be(false)
-        expect(ignored_method.ignored?(C, true, :new)).to be(true)
+        expect(ignored_method.ignored(A, true, :new)).to be(:all)
+        expect(ignored_method.ignored(B, true, :new)).to be(false)
+        expect(ignored_method.ignored(C, true, :new)).to be(:all)
       end
 
       it 'returns true if instance method is matched' do
@@ -65,14 +73,12 @@ RSpec.describe DiverDown::Trace::IgnoredMethodIds do
         stub_const('C', Class.new(A))
 
         ignored_method = described_class.new(
-          [
-            'A#initialize',
-          ]
+          'A#initialize' => :all
         )
 
-        expect(ignored_method.ignored?(A, false, :initialize)).to be(true)
-        expect(ignored_method.ignored?(B, false, :initialize)).to be(false)
-        expect(ignored_method.ignored?(C, false, :initialize)).to be(true)
+        expect(ignored_method.ignored(A, false, :initialize)).to be(:all)
+        expect(ignored_method.ignored(B, false, :initialize)).to be(false)
+        expect(ignored_method.ignored(C, false, :initialize)).to be(:all)
       end
     end
   end

--- a/spec/diver_down/trace/tracer_spec.rb
+++ b/spec/diver_down/trace/tracer_spec.rb
@@ -653,9 +653,9 @@ RSpec.describe DiverDown::Trace::Tracer do
       it 'traces tracer_ignored_call_stack.rb' do
         definition = trace_fixture(
           'tracer_ignored_call_stack.rb',
-          ignored_method_ids: [
-            'AntipollutionModule::B.class_call',
-          ],
+          ignored_method_ids: {
+            'AntipollutionModule::B.class_call' => :all,
+          },
           module_set: {
             modules: [
               'AntipollutionModule::A',
@@ -683,6 +683,67 @@ RSpec.describe DiverDown::Trace::Tracer do
                       context: 'class',
                       paths: [
                         match(/tracer_ignored_call_stack\.rb:\d+/),
+                      ],
+                    },
+                  ],
+                },
+              ],
+            }, {
+              source_name: 'AntipollutionModule::D', dependencies: [],
+            },
+          ]
+        ))
+      end
+
+      it 'traces tracer_ignored_call_stack.rb, single' do
+        definition = trace_fixture(
+          'tracer_ignored_single_call_stack.rb',
+          ignored_method_ids: {
+            'AntipollutionModule::B.class_call' => :single,
+          },
+          module_set: {
+            modules: [
+              'AntipollutionModule::A',
+              'AntipollutionModule::B',
+              'AntipollutionModule::C',
+              'AntipollutionModule::D',
+            ],
+          },
+          caller_paths: [
+            fixture_path('tracer_ignored_single_call_stack.rb'),
+          ]
+        )
+
+        expect(definition.to_h).to match(fill_default(
+          title: 'title',
+          sources: [
+            {
+              source_name: 'AntipollutionModule::A',
+              dependencies: [
+                {
+                  source_name: 'AntipollutionModule::C',
+                  method_ids: [
+                    {
+                      name: 'class_call',
+                      context: 'class',
+                      paths: [
+                        match(/tracer_ignored_single_call_stack\.rb:\d+/),
+                      ],
+                    },
+                  ],
+                },
+              ],
+            }, {
+              source_name: 'AntipollutionModule::C',
+              dependencies: [
+                {
+                  source_name: 'AntipollutionModule::D',
+                  method_ids: [
+                    {
+                      name: 'class_call',
+                      context: 'class',
+                      paths: [
+                        match(/tracer_ignored_single_call_stack\.rb:\d+/),
                       ],
                     },
                   ],

--- a/spec/fixtures/tracer_ignored_single_call_stack.rb
+++ b/spec/fixtures/tracer_ignored_single_call_stack.rb
@@ -1,0 +1,27 @@
+def run
+  A.class_call
+end
+
+class A
+  def self.class_call
+    B.class_call
+  end
+end
+
+class B
+  def self.class_call
+    C.class_call
+  end
+end
+
+class C
+  def self.class_call
+    D.class_call
+  end
+end
+
+class D
+  def self.class_call
+    nil
+  end
+end


### PR DESCRIPTION
Extended ignored_method_ids.

Previously, all call stacks after the specified method was ignored.
After this PR changes, you can choose to exclude only the call stack of that method from tracing instead of full call stack.

The way options are specified has changed.

```
# before
ignored_method_ids: ['A.class_call']

# after
ignored_method_ids: {
  'A.class_call' => :full, # same original behavior
  'A.bar' => :single # new behavior
}
```