### PR TITLE
Convert paths to GitHub urls using blob-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ This gem is specifically designed to analyze large applications with a modular m
 
 - `--definition-dir` Specifies the directory where the analysis results are stored.
 - `--metadata` Designates a path to save the results that include details on which module each file belongs to. If this option is not specified, the results will be temporarily stored in a default temporary file.
+- `--blob-prefix` Specifies the prefix used to construct GitHub URLs for files, allowing direct access to the repository’s source code.
 
 ```sh
-bundle exec diver_down_web --definition-dir tmp/diver_down --metadata tmp/metadata.yml
+bundle exec diver_down_web --definition-dir tmp/diver_down --metadata tmp/metadata.yml --blob-prefix https://github.com/alpaca-tc/diver_down/blob/main
 open http://localhost:8080
 ```
 

--- a/config.ru
+++ b/config.ru
@@ -8,8 +8,9 @@ require 'puma'
 
 definition_dir = ENV.fetch('DIVER_DOWN_DIR')
 metadata = DiverDown::Web::Metadata.new(ENV.fetch('DIVER_DOWN_METADATA'))
+blob_prefix = ENV['DIVER_DOWN_BLOB_PREFIX']
 
 use Rack::Reloader
 use Rack::JSONBodyParser
 use DiverDown::Web::DevServerMiddleware, host: 'localhost', port: 5173 # Proxy to vite(pnpm run dev)
-run DiverDown::Web.new(definition_dir:, metadata:)
+run DiverDown::Web.new(definition_dir:, metadata:, blob_prefix:)

--- a/exe/diver_down_web
+++ b/exe/diver_down_web
@@ -14,7 +14,7 @@ option_parser = OptionParser.new do |opts|
     Usage: diver_down_web [options]
 
     Example:
-      diver_down_web --definition-dir /path/to/definitions --metadata /path/to/metadata.yml
+      diver_down_web --definition-dir /path/to/definitions --metadata /path/to/metadata.yml --blob-prefix https://github.com/owner/repo/blob/master
 
     Options:
   BANNER
@@ -25,6 +25,10 @@ option_parser = OptionParser.new do |opts|
 
   opts.on('--metadata PATH', 'Path to the metadata.yml') do |path|
     options[:metadata] = path
+  end
+
+  opts.on('--blob-prefix URL', 'blob url prefix for paths') do |url|
+    options[:blob_prefix] = url
   end
 end
 option_parser.parse!(ARGV)
@@ -39,7 +43,8 @@ end
 app = Rack::JSONBodyParser.new(
   DiverDown::Web.new(
     definition_dir: options.fetch(:definition_dir),
-    metadata: DiverDown::Web::Metadata.new(options[:metadata] || Tempfile.new(['metadata', '.yaml']).path)
+    metadata: DiverDown::Web::Metadata.new(options[:metadata] || Tempfile.new(['metadata', '.yaml']).path),
+    blob_prefix: option_parser.blob_prefix
   )
 )
 

--- a/frontend/constants/path.ts
+++ b/frontend/constants/path.ts
@@ -20,6 +20,7 @@ export const path = {
     index: () => '/licenses',
   },
   api: {
+    configuration: () => `/api/configuration.json`,
     pid: () => `/api/pid.json`,
     initializationStatus: () => `/api/initialization_status.json`,
     definitions: {

--- a/frontend/models/configuration.ts
+++ b/frontend/models/configuration.ts
@@ -1,0 +1,3 @@
+export type Configuration = {
+  blobPrefix: string | null
+}

--- a/frontend/pages/Modules/components/SourceRow/SourceRow.tsx
+++ b/frontend/pages/Modules/components/SourceRow/SourceRow.tsx
@@ -8,6 +8,7 @@ import { SourceMemoInput } from '@/components/SourceMemoInput'
 import { SourceDependencyTypeSelect } from '../SourceDependencyTypeSelect'
 import styled from 'styled-components'
 import { useConfiguration } from '@/repositories/configurationRepository'
+import { toBlobSuffix } from '@/utils/toBlobSuffix'
 
 type Props = {
   mutate: () => void
@@ -50,28 +51,11 @@ export const SourceRow: FC<Props> = ({ mutate, source, filteredModule }) => {
     return [...set].sort()
   }, [dependencies])
 
-  const blobPrefix: null | string = useMemo(() => {
-    if (configuration?.blobPrefix) {
-      return configuration.blobPrefix.replace(/\/$/, '')
-    } else {
-      return null
-    }
-  }, [configuration])
+  const blobPrefix = configuration?.blobPrefix ?? null
 
   const onUpdated = useCallback(() => {
     mutate()
   }, [source, mutate])
-
-  const toBlobSuffix = (fullPath: string) => {
-    const chunks = fullPath.split(':')
-
-    if (chunks.length > 1 && chunks[chunks.length - 1].match(/^\d+$/)) {
-      const line = chunks.pop()
-      return `${chunks.join(':')}#L${line}`
-    } else {
-      return chunks.join(':')
-    }
-  }
 
   return (
     <>

--- a/frontend/pages/Sources/Show.tsx
+++ b/frontend/pages/Sources/Show.tsx
@@ -12,10 +12,15 @@ import { useSource } from '@/repositories/sourceRepository'
 import { encode, idsToBitId } from '@/utils/bitId'
 import { stringify } from '@/utils/queryString'
 import { Module } from '@/models/module'
+import { toBlobSuffix } from '@/utils/toBlobSuffix'
+import { useConfiguration } from '@/repositories/configurationRepository'
 
 export const Show: React.FC = () => {
   const sourceName = useParams().sourceName ?? ''
   const { specificSource, isLoading } = useSource(sourceName)
+  const { data: configuration } = useConfiguration()
+
+  const blobPrefix = configuration?.blobPrefix ?? null
 
   const relatedDefinitionIds = useMemo(() => {
     if (specificSource) {
@@ -204,7 +209,13 @@ export const Show: React.FC = () => {
                                     <div
                                       key={`${reverseDependency.sourceName}-${methodId.context}-${methodId.name}-${methodIdPath}`}
                                     >
-                                      <Text>{methodIdPath}</Text>
+                                      {blobPrefix ? (
+                                        <Link target="_blank" to={`${blobPrefix}/${toBlobSuffix(methodIdPath)}`}>
+                                          {methodIdPath}
+                                        </Link>
+                                      ) : (
+                                        <Text>{methodIdPath}</Text>
+                                      )}
                                     </div>
                                   ))}
                                 </Td>

--- a/frontend/repositories/configurationRepository.ts
+++ b/frontend/repositories/configurationRepository.ts
@@ -1,0 +1,20 @@
+import useSWR from 'swr'
+
+import { path } from '@/constants/path'
+import { get } from './httpRequest'
+import { Configuration } from '@/models/configuration'
+
+type ConfigurationReponse = {
+  blob_prefix: string | null
+}
+
+export const useConfiguration = () => {
+  const { data, isLoading } = useSWR<Configuration>(path.api.configuration(), async () => {
+    const response = await get<ConfigurationReponse>(path.api.configuration())
+    return {
+      blobPrefix: response.blob_prefix,
+    }
+  })
+
+  return { data, isLoading }
+}

--- a/frontend/utils/__tests__/toBlobSuffix.test.ts
+++ b/frontend/utils/__tests__/toBlobSuffix.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { toBlobSuffix } from '../toBlobSuffix'
+
+describe('toBlobSuffix', () => {
+  it('returns github style line', () => {
+    expect(toBlobSuffix('app.rb:2')).toEqual('app.rb#L2')
+  })
+
+  it('returns raw string if it contains multiple :', () => {
+    expect(toBlobSuffix('app.rb:2:2')).toEqual('app.rb:2#L2')
+  })
+})

--- a/frontend/utils/toBlobSuffix.ts
+++ b/frontend/utils/toBlobSuffix.ts
@@ -1,0 +1,10 @@
+export const toBlobSuffix = (fullPath: string) => {
+  const chunks = fullPath.split(':')
+
+  if (chunks.length > 1 && chunks[chunks.length - 1].match(/^\d+$/)) {
+    const line = chunks.pop()
+    return `${chunks.join(':')}#L${line}`
+  } else {
+    return chunks.join(':')
+  }
+}

--- a/lib/diver_down/web.rb
+++ b/lib/diver_down/web.rb
@@ -29,9 +29,11 @@ module DiverDown
 
     # @param definition_dir [String]
     # @param metadata [DiverDown::Web::Metadata]
+    # @param blob_prefix [String]
     # @param store [DiverDown::Web::DefinitionStore]
-    def initialize(definition_dir:, metadata:)
+    def initialize(definition_dir:, metadata:, blob_prefix:)
       @metadata = metadata
+      @blob_prefix = blob_prefix
       @files_server = Rack::Files.new(File.join(WEB_DIR))
 
       definition_files = ::Dir["#{definition_dir}/**/*.{yml,yaml,msgpack,json}"].sort
@@ -47,7 +49,7 @@ module DiverDown
       request = Rack::Request.new(env)
 
       if @action&.store.object_id != self.class.store.object_id
-        @action = DiverDown::Web::Action.new(store: self.class.store, metadata: @metadata)
+        @action = DiverDown::Web::Action.new(store: self.class.store, metadata: @metadata, blob_prefix: @blob_prefix)
       end
 
       case [request.request_method, request.path]
@@ -104,6 +106,8 @@ module DiverDown
         @action.pid
       in ['GET', %r{\A/api/initialization_status\.json\z}]
         @action.initialization_status(@total_definition_files_size)
+      in ['GET', %r{\A/api/configuration\.json\z}]
+        @action.configuration
       in ['GET', %r{\A/api/source_aliases\.json\z}]
         @action.source_aliases
       in ['POST', %r{\A/api/source_aliases\.json\z}]

--- a/lib/diver_down/web.rb
+++ b/lib/diver_down/web.rb
@@ -33,7 +33,7 @@ module DiverDown
     # @param store [DiverDown::Web::DefinitionStore]
     def initialize(definition_dir:, metadata:, blob_prefix:)
       @metadata = metadata
-      @blob_prefix = blob_prefix
+      @blob_prefix = blob_prefix&.sub(%r{/+$}, '')
       @files_server = Rack::Files.new(File.join(WEB_DIR))
 
       definition_files = ::Dir["#{definition_dir}/**/*.{yml,yaml,msgpack,json}"].sort

--- a/lib/diver_down/web/action.rb
+++ b/lib/diver_down/web/action.rb
@@ -18,9 +18,10 @@ module DiverDown
 
       # @param store [DiverDown::Definition::Store]
       # @param metadata [DiverDown::Web::Metadata]
-      def initialize(store:, metadata:)
+      def initialize(store:, metadata:, blob_prefix:)
         @store = store
         @metadata = metadata
+        @blob_prefix = blob_prefix
 
         reload
       end
@@ -183,6 +184,13 @@ module DiverDown
         json(
           total:,
           loaded: @store.size
+        )
+      end
+
+      # GET /api/configuration.json
+      def configuration
+        json(
+          blob_prefix: @blob_prefix
         )
       end
 

--- a/spec/diver_down/web_spec.rb
+++ b/spec/diver_down/web_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe DiverDown::Web do
   include Rack::Test::Methods
 
   def app
-    @app ||= described_class.new(definition_dir:, metadata:)
+    @app ||= described_class.new(definition_dir:, metadata:, blob_prefix:)
   end
 
   let(:definition_dir) do
@@ -18,6 +18,10 @@ RSpec.describe DiverDown::Web do
   let(:metadata) do
     metadata_path = Tempfile.new(['test', '.yaml']).path
     DiverDown::Web::Metadata.new(metadata_path)
+  end
+
+  let(:blob_prefix) do
+    nil
   end
 
   before do
@@ -244,6 +248,32 @@ RSpec.describe DiverDown::Web do
         assert_definition_group 'group', [definition_1_id, definition_2_id]
         assert_definition_group 'group_1', [definition_1_id]
         assert_definition_group 'group_2', [definition_2_id]
+      end
+    end
+  end
+
+  describe 'GET /api/configuration.json' do
+    context 'blob_prefix is nil' do
+      it 'returns blob_prefix' do
+        get '/api/configuration.json'
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)).to eq({
+          'blob_prefix' => nil,
+        })
+      end
+    end
+
+    context 'blob_prefix is present' do
+      let(:blob_prefix) { 'https://github.com/alpaca-tc/diver_down/blob/main' }
+
+      it 'returns blob_prefix' do
+        get '/api/configuration.json'
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)).to eq({
+          'blob_prefix' => blob_prefix,
+        })
       end
     end
   end


### PR DESCRIPTION
### Description  
This PR introduces support for converting file paths into GitHub URLs using a **blob prefix**. By specifying the `--blob-prefix` option, users can generate direct links to the repository’s source code, making it easier to navigate and reference files.  

### Changes  
- Added `--blob-prefix` option to construct GitHub URLs.  
- Updated documentation to reflect the new option.  
- Enhanced CLI output to include generated URLs when the option is provided.  

### Usage  
```sh
bundle exec diver_down_web ... --blob-prefix="https://github.com/org/repo/blob/main/"
```

### Why?  
This feature improves usability by providing direct links to analyzed files, making it more convenient for users to inspect source code.